### PR TITLE
Improve Makefile to make sure rendered notebook is not empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,12 @@ MINIMAL_RENDERED_NOTEBOOK_FILES = $(shell ls $(PYTHON_SCRIPTS_DIR)/*.py | perl -
 
 all: $(RENDERED_NOTEBOOKS_DIR)
 
-.PHONY: $(RENDERED_NOTEBOOKS_DIR) sanity_check_$(PYTHON_SCRIPTS_DIR) sanity_check_$(RENDERED_NOTEBOOKS_DIR) all
+.PHONY: $(RENDERED_NOTEBOOKS_DIR) sanity_check_$(PYTHON_SCRIPTS_DIR) sanity_check_$(RENDERED_NOTEBOOKS_DIR) all clean
 
 $(RENDERED_NOTEBOOKS_DIR): $(MINIMAL_RENDERED_NOTEBOOK_FILES) sanity_check_$(RENDERED_NOTEBOOKS_DIR)
 
 $(RENDERED_NOTEBOOKS_DIR)/%.ipynb: $(PYTHON_SCRIPTS_DIR)/%.py
-	jupytext --to notebook --output $@ $< 
-	jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=None \
-                    --ExecutePreprocessor.kernel_name=$(JUPYTER_KERNEL) --inplace $@
+	bash build_scripts/convert-python-script-to-notebook.sh $< $@ $(JUPYTER_KERNEL)
 
 sanity_check_$(PYTHON_SCRIPTS_DIR):
 	python build_scripts/check-python-scripts.py $(PYTHON_SCRIPTS_DIR)
@@ -20,3 +18,6 @@ sanity_check_$(PYTHON_SCRIPTS_DIR):
 
 sanity_check_$(RENDERED_NOTEBOOKS_DIR):
 	python build_scripts/sanity-check.py $(PYTHON_SCRIPTS_DIR) $(RENDERED_NOTEBOOKS_DIR)
+
+clean:
+	rm -rf $(RENDERED_NOTEBOOKS_DIR)/*tmp.ipynb

--- a/build_scripts/convert-python-script-to-notebook.sh
+++ b/build_scripts/convert-python-script-to-notebook.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+PYTHON_SCRIPT=$1
+NOTEBOOK=$2
+JUPYTER_KERNEL=$3
+
+TMP_NOTEBOOK=${NOTEBOOK/.ipynb/_tmp.ipynb}
+jupytext --to notebook --output $TMP_NOTEBOOK $PYTHON_SCRIPT
+jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=None \
+        --ExecutePreprocessor.kernel_name=$JUPYTER_KERNEL --inplace $TMP_NOTEBOOK
+
+# Only move the temporary notebook if all the previous command have been successful
+mv $TMP_NOTEBOOK $NOTEBOOK


### PR DESCRIPTION
If the notebook execution fails, `rendered_notebook/the_notebook_name.ipynb` is generated empty and running `make` again will not trigger a rebuild.

This PR fixes this problem. It also moves the logic to an external script because I am getting annoyed by the `Makefile` limitations and I don't want to have to remember all these quirks ...