### PR TITLE
Pin matplotlib to avoid matplotlib 3.3.1 regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 scikit-learn
 pandas
 pandas-profiling
-matplotlib
+matplotlib==3.3.0
 seaborn
 plotly
 jupyter


### PR DESCRIPTION
Due to https://github.com/matplotlib/matplotlib/issues/18254.

Example build failure: https://app.circleci.com/pipelines/github/INRIA/scikit-learn-mooc/155/workflows/9e1b06a1-af33-4c96-95d3-c0114df6be2e/jobs/156

Pinning to matplotlib 3.3.0 until 3.3.2 is released.
