### PR TITLE
Add CI status to point directly to CircleCI website.

### DIFF
--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -1,0 +1,12 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/jupyter-book/index.html
+          circleci-jobs: build_jupyter_book


### PR DESCRIPTION
This would be easier to see the generated website directly in a PR.