### PR TITLE
Fix dtype filtering on int error on Windows.

### DIFF
--- a/notebooks/02_numerical_pipeline.ipynb
+++ b/notebooks/02_numerical_pipeline.ipynb
@@ -121,7 +121,7 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "numerical_columns_selector = selector(dtype_include=[\"int\", \"float\"])\n",
+    "numerical_columns_selector = selector(dtype_exclude=object)\n",
     "numerical_columns = numerical_columns_selector(data)\n",
     "numerical_columns"
    ]

--- a/notebooks/02_numerical_pipeline_ex_01.ipynb
+++ b/notebooks/02_numerical_pipeline_ex_01.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "numerical_columns_selector = selector(dtype_include=[\"int\", \"float\"])\n",
+    "numerical_columns_selector = selector(dtype_exclude=object)\n",
     "numerical_columns = numerical_columns_selector(data)\n",
     "data_numeric = data[numerical_columns]"
    ]

--- a/notebooks/02_numerical_pipeline_scaling.ipynb
+++ b/notebooks/02_numerical_pipeline_scaling.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "numerical_columns_selector = selector(dtype_include=[\"int\", \"float\"])\n",
+    "numerical_columns_selector = selector(dtype_exclude=object)\n",
     "numerical_columns = numerical_columns_selector(data)\n",
     "numerical_columns\n",
     "\n",

--- a/notebooks/02_numerical_pipeline_sol_01.ipynb
+++ b/notebooks/02_numerical_pipeline_sol_01.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "numerical_columns_selector = selector(dtype_include=[\"int\", \"float\"])\n",
+    "numerical_columns_selector = selector(dtype_exclude=object)\n",
     "numerical_columns = numerical_columns_selector(data)\n",
     "data_numeric = data[numerical_columns]"
    ]

--- a/notebooks/03_categorical_pipeline.ipynb
+++ b/notebooks/03_categorical_pipeline.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "categorical_columns_selector = selector(dtype_exclude=[\"int\", \"float\"])\n",
+    "categorical_columns_selector = selector(dtype_include=object)\n",
     "categorical_columns = categorical_columns_selector(data)\n",
     "categorical_columns"
    ]

--- a/notebooks/03_categorical_pipeline_column_transformer.ipynb
+++ b/notebooks/03_categorical_pipeline_column_transformer.ipynb
@@ -50,11 +50,11 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "categorical_columns_selector = selector(dtype_exclude=[\"int\", \"float\"])\n",
-    "categorical_columns = categorical_columns_selector(data)\n",
+    "numerical_columns_selector = selector(dtype_exclude=object)\n",
+    "categorical_columns_selector = selector(dtype_include=object)\n",
     "\n",
-    "numerical_columns_selector = selector(dtype_include=[\"int\", \"float\"])\n",
-    "numerical_columns = numerical_columns_selector(data)"
+    "numerical_columns = numerical_columns_selector(data)\n",
+    "categorical_columns = categorical_columns_selector(data)"
    ]
   },
   {

--- a/notebooks/03_categorical_pipeline_ex_01.ipynb
+++ b/notebooks/03_categorical_pipeline_ex_01.ipynb
@@ -57,7 +57,7 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "categorical_columns_selector = selector(dtype_exclude=[\"int\", \"float\"])\n",
+    "categorical_columns_selector = selector(dtype_include=object)\n",
     "categorical_columns = categorical_columns_selector(data)\n",
     "data_categorical = data[categorical_columns]"
    ]

--- a/notebooks/03_categorical_pipeline_ex_02.ipynb
+++ b/notebooks/03_categorical_pipeline_ex_02.ipynb
@@ -49,8 +49,8 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "numerical_columns_selector = selector(dtype_include=[\"int\", \"float\"])\n",
-    "categorical_columns_selector = selector(dtype_exclude=[\"int\", \"float\"])\n",
+    "numerical_columns_selector = selector(dtype_exclude=object)\n",
+    "categorical_columns_selector = selector(dtype_include=object)\n",
     "numerical_columns = numerical_columns_selector(data)\n",
     "categorical_columns = categorical_columns_selector(data)\n",
     "\n",

--- a/notebooks/03_categorical_pipeline_sol_01.ipynb
+++ b/notebooks/03_categorical_pipeline_sol_01.ipynb
@@ -57,7 +57,7 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "categorical_columns_selector = selector(dtype_exclude=[\"int\", \"float\"])\n",
+    "categorical_columns_selector = selector(dtype_include=object)\n",
     "categorical_columns = categorical_columns_selector(data)\n",
     "data_categorical = data[categorical_columns]"
    ]

--- a/notebooks/03_categorical_pipeline_sol_02.ipynb
+++ b/notebooks/03_categorical_pipeline_sol_02.ipynb
@@ -53,8 +53,8 @@
    "source": [
     "from sklearn.compose import make_column_selector as selector\n",
     "\n",
-    "numerical_columns_selector = selector(dtype_include=[\"int\", \"float\"])\n",
-    "categorical_columns_selector = selector(dtype_exclude=[\"int\", \"float\"])\n",
+    "numerical_columns_selector = selector(dtype_exclude=object)\n",
+    "categorical_columns_selector = selector(dtype_include=object)\n",
     "numerical_columns = numerical_columns_selector(data)\n",
     "categorical_columns = categorical_columns_selector(data)\n",
     "\n",

--- a/python_scripts/02_numerical_pipeline.py
+++ b/python_scripts/02_numerical_pipeline.py
@@ -75,7 +75,7 @@ data.dtypes
 # %%
 from sklearn.compose import make_column_selector as selector
 
-numerical_columns_selector = selector(dtype_include=["int", "float"])
+numerical_columns_selector = selector(dtype_exclude=object)
 numerical_columns = numerical_columns_selector(data)
 numerical_columns
 

--- a/python_scripts/02_numerical_pipeline_ex_01.py
+++ b/python_scripts/02_numerical_pipeline_ex_01.py
@@ -42,7 +42,7 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-numerical_columns_selector = selector(dtype_include=["int", "float"])
+numerical_columns_selector = selector(dtype_exclude=object)
 numerical_columns = numerical_columns_selector(data)
 data_numeric = data[numerical_columns]
 

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -43,7 +43,7 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-numerical_columns_selector = selector(dtype_include=["int", "float"])
+numerical_columns_selector = selector(dtype_exclude=object)
 numerical_columns = numerical_columns_selector(data)
 numerical_columns
 

--- a/python_scripts/02_numerical_pipeline_sol_01.py
+++ b/python_scripts/02_numerical_pipeline_sol_01.py
@@ -42,7 +42,7 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-numerical_columns_selector = selector(dtype_include=["int", "float"])
+numerical_columns_selector = selector(dtype_exclude=object)
 numerical_columns = numerical_columns_selector(data)
 data_numeric = data[numerical_columns]
 

--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -60,7 +60,7 @@ data.dtypes
 # %%
 from sklearn.compose import make_column_selector as selector
 
-categorical_columns_selector = selector(dtype_exclude=["int", "float"])
+categorical_columns_selector = selector(dtype_include=object)
 categorical_columns = categorical_columns_selector(data)
 categorical_columns
 

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -37,11 +37,11 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-categorical_columns_selector = selector(dtype_exclude=["int", "float"])
-categorical_columns = categorical_columns_selector(data)
+numerical_columns_selector = selector(dtype_exclude=object)
+categorical_columns_selector = selector(dtype_include=object)
 
-numerical_columns_selector = selector(dtype_include=["int", "float"])
 numerical_columns = numerical_columns_selector(data)
+categorical_columns = categorical_columns_selector(data)
 
 # %% [markdown]
 # ## ColumnTransformer

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -48,7 +48,7 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-categorical_columns_selector = selector(dtype_exclude=["int", "float"])
+categorical_columns_selector = selector(dtype_include=object)
 categorical_columns = categorical_columns_selector(data)
 data_categorical = data[categorical_columns]
 

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -40,8 +40,8 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-numerical_columns_selector = selector(dtype_include=["int", "float"])
-categorical_columns_selector = selector(dtype_exclude=["int", "float"])
+numerical_columns_selector = selector(dtype_exclude=object)
+categorical_columns_selector = selector(dtype_include=object)
 numerical_columns = numerical_columns_selector(data)
 categorical_columns = categorical_columns_selector(data)
 

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -48,7 +48,7 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-categorical_columns_selector = selector(dtype_exclude=["int", "float"])
+categorical_columns_selector = selector(dtype_include=object)
 categorical_columns = categorical_columns_selector(data)
 data_categorical = data[categorical_columns]
 

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -44,8 +44,8 @@ data = df.drop(columns=[target_name, "fnlwgt"])
 # %%
 from sklearn.compose import make_column_selector as selector
 
-numerical_columns_selector = selector(dtype_include=["int", "float"])
-categorical_columns_selector = selector(dtype_exclude=["int", "float"])
+numerical_columns_selector = selector(dtype_exclude=object)
+categorical_columns_selector = selector(dtype_include=object)
 numerical_columns = numerical_columns_selector(data)
 categorical_columns = categorical_columns_selector(data)
 


### PR DESCRIPTION
Although not exactly the same, this feels simpler to use `dtype_include=object` rather than `dtype_exclude=["int", "float"]`

