### PR TITLE
Use binary encoding for sex in exercise for consistency.

### DIFF
--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -23,7 +23,7 @@
 # variables. This preprocessor is assembled in a pipeline with
 # `LogisticRegression`. The performance of the pipeline can be evaluated as
 # usual by cross-validation and then compared to the score obtained when using
-# `OneHotEncoding` or to some other baseline score.
+# `OneHotEncoder` or to some other baseline score.
 #
 # Because `OrdinalEncoder` can raise errors if it sees an unknown category at
 # prediction time, we need to pre-compute the list of all possible categories

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -93,8 +93,8 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
 # %% [markdown]
 # Reminder: in order to avoid creating fully correlated features it is
-# preferable to use a `OrdinalEncoder` for binary features, in this case
-# `sex`.
+# preferable to use a `OrdinalEncoder` for binary features (in this case `sex`)
+# rather than a `OneHotEncoder`.
 
 # %%
 binary_encoding_columns = ['sex']

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -15,11 +15,16 @@
 # %% [markdown]
 # # 📝 Exercise 02
 #
-# The goal of this exercise is to evaluate the impact of feature preprocessing on a pipeline that uses a  decision-tree-based classifier instead of logistic regression.
+# The goal of this exercise is to evaluate the impact of feature preprocessing
+# on a pipeline that uses a decision-tree-based classifier instead of logistic
+# regression.
 #
-# - The first question is to empirically evaluate whether scaling numerical feature is helpful or not;
+# - The first question is to empirically evaluate whether scaling numerical
+#   feature is helpful or not;
 #
-# - The second question is to evaluate whether it is empirically better (both from a computational and a statistical perspective) to use integer coded or one-hot encoded categories.
+# - The second question is to evaluate whether it is empirically better (both
+#   from a computational and a statistical perspective) to use integer coded or
+#   one-hot encoded categories.
 
 # %%
 import pandas as pd
@@ -51,7 +56,8 @@ categories = [
 # %% [markdown]
 # ## Reference pipeline (no numerical scaling and integer-coded categories)
 #
-# First let's time the pipeline we used in the main notebook to serve as a reference:
+# First let's time the pipeline we used in the main notebook to serve as a
+# reference:
 
 # %%
 # %%time
@@ -68,7 +74,8 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # %% [markdown]
 # ## Scaling numerical features
 #
-# Let's write a similar pipeline that also scales the numerical features using `StandardScaler` (or similar):
+# Let's write a similar pipeline that also scales the numerical features using
+# `StandardScaler` (or similar):
 
 # %%
 # Write your code here.
@@ -82,10 +89,23 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # case as the cross-validation of the reference pipeline with
 # `OrdinalEncoder` is good.
 #
-# Let's see if we can get an even better accuracy with `OneHotEncoding`.
-#
-# Hint: `HistGradientBoostingClassifier` does not yet support sparse input data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a dense representation as a workaround.
+# Let's see if we can get an even better accuracy with `OneHotEncoder`.
+
+# %% [markdown]
+# Reminder: in order to avoid creating fully correlated features it is
+# preferable to use a `OrdinalEncoder` for binary features, in this case
+# `sex`.
+
+# %%
+binary_encoding_columns = ['sex']
+one_hot_encoding_columns = [
+    c for c in categorical_columns if c not in binary_encoding_columns]
+
+# %% [markdown]
+# Hint: `HistGradientBoostingClassifier` does not yet support sparse input
+# data. You might want to use
+# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a
+# dense representation as a workaround.
 
 # %%
 # Write your code here.

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -23,7 +23,7 @@
 # variables. This preprocessor is assembled in a pipeline with
 # `LogisticRegression`. The performance of the pipeline can be evaluated as
 # usual by cross-validation and then compared to the score obtained when using
-# `OneHotEncoding` or to some other baseline score.
+# `OneHotEncoder` or to some other baseline score.
 #
 # Because `OrdinalEncoder` can raise errors if it sees an unknown category at
 # prediction time, we need to pre-compute the list of all possible categories

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -15,15 +15,22 @@
 # %% [markdown]
 # # 📃 Solution for Exercise 02
 #
-# The goal of this exercise is to evaluate the impact of feature preprocessing on a pipeline that uses a  decision-tree-based classifier instead of logistic regression.
+# The goal of this exercise is to evaluate the impact of feature preprocessing
+# on a pipeline that uses a decision-tree-based classifier instead of logistic
+# regression.
 #
-# - The first question is to empirically evaluate whether scaling numerical feature is helpful or not;
+# - The first question is to empirically evaluate whether scaling numerical
+#   feature is helpful or not;
 #
-# - The second question is to evaluate whether it is empirically better (both from a computational and a statistical perspective) to use integer coded or one-hot encoded categories.
+# - The second question is to evaluate whether it is empirically better (both
+#   from a computational and a statistical perspective) to use integer coded or
+#   one-hot encoded categories.
 #
 #
-# Hint: `HistGradientBoostingClassifier` does not yet support sparse input data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a dense representation as a workaround.
+# Hint: `HistGradientBoostingClassifier` does not yet support sparse input
+# data. You might want to use
+# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a
+# dense representation as a workaround.
 
 # %%
 import pandas as pd
@@ -55,7 +62,8 @@ categories = [
 # %% [markdown]
 # ## Reference pipeline (no numerical scaling and integer-coded categories)
 #
-# First let's time the pipeline we used in the main notebook to serve as a reference:
+# First let's time the pipeline we used in the main notebook to serve as a
+# reference:
 
 # %%
 # %%time
@@ -89,9 +97,12 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # %% [markdown]
 # ### Analysis
 #
-# We can observe that both the accuracy and the training time are approximately the same as the reference pipeline (any time difference you might observe is not significant).
+# We can observe that both the accuracy and the training time are approximately
+# the same as the reference pipeline (any time difference you might observe is
+# not significant).
 #
-# Scaling numerical features is indeed useless for most decision tree models in general and for `HistGradientBoostingClassifier` in particular.
+# Scaling numerical features is indeed useless for most decision tree models in
+# general and for `HistGradientBoostingClassifier` in particular.
 
 # %% [markdown]
 # ## One-hot encoding of categorical variables
@@ -102,16 +113,34 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # case as the cross-validation of the reference pipeline with
 # `OrdinalEncoder` is good.
 #
-# Let's see if we can get an even better accuracy with `OneHotEncoding`:
+# Let's see if we can get an even better accuracy with `OneHotEncoder`:
+
+# %% [markdown]
+# Reminder: in order to avoid creating two fully correlated features for binary
+# features it is preferable to use a `OrdinalEncoder` rather than a
+# `OneHotEncoder.
+
+# %%
+binary_encoding_columns = ['sex']
+one_hot_encoding_columns = [
+    c for c in categorical_columns if c not in binary_encoding_columns]
+
+# %% [markdown]
+# Hint: `HistGradientBoostingClassifier` does not yet support sparse input
+# data. You might want to use
+# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a
+# dense representation as a workaround.
 
 # %%
 # %%time
 from sklearn.preprocessing import OneHotEncoder
 
 preprocessor = ColumnTransformer([
-    ('categorical',
+    ('binary-encoder', OrdinalEncoder(), binary_encoding_columns),
+    ('one-hot-encoder',
      OneHotEncoder(handle_unknown="ignore", sparse=False),
-     categorical_columns),], remainder="passthrough")
+     one_hot_encoding_columns)],
+    remainder="passthrough")
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
 scores = cross_val_score(model, data, target)

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -116,9 +116,9 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # Let's see if we can get an even better accuracy with `OneHotEncoder`:
 
 # %% [markdown]
-# Reminder: in order to avoid creating two fully correlated features for binary
-# features it is preferable to use a `OrdinalEncoder` rather than a
-# `OneHotEncoder.
+# Reminder: in order to avoid creating fully correlated features it is
+# preferable to use a `OrdinalEncoder` for binary features (in this case `sex`)
+# rather than a `OneHotEncoder`.
 
 # %%
 binary_encoding_columns = ['sex']


### PR DESCRIPTION
Fix #93 

Fixed long markdown lines while I was at it (and also a few `OneHotEncoding` rather than `OneHotEncoder`)

In practice this kind of inconsistency make people struggle while they try to do the exercises because they copy and paste from a different notebook where the code is slightly different (e.g. variable names or in this case binary encoding of sex or not).