### PR TITLE
ENH specify categories and use drop=if_binary

### DIFF
--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -217,7 +217,8 @@ from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import LogisticRegression
 
 model = make_pipeline(
-    OneHotEncoder(categories=categories), LogisticRegression())
+    OneHotEncoder(categories=categories, drop="if_binary"),
+    LogisticRegression())
 
 # %% [markdown]
 # Finally, we can check the model's performance only using the categorical

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -62,9 +62,10 @@ categories = [
 # %%
 # %%time
 
+categorical_preprocessor = OrdinalEncoder(categories=categories)
 preprocessor = ColumnTransformer([
-    ('categorical', OrdinalEncoder(categories=categories),
-     categorical_columns),], remainder="passthrough")
+    ('categorical', categorical_preprocessor, categorical_columns)],
+    remainder="passthrough")
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
 scores = cross_val_score(model, data, target)
@@ -93,18 +94,12 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
 # %% [markdown]
 # Reminder: in order to avoid creating fully correlated features it is
-# preferable to use a `OrdinalEncoder` for binary features (in this case `sex`)
-# rather than a `OneHotEncoder`.
-
-# %%
-binary_encoding_columns = ['sex']
-one_hot_encoding_columns = [
-    c for c in categorical_columns if c not in binary_encoding_columns]
+# preferable to use a `OneHotEncoder` using the option `drop="if_binary"`.
 
 # %% [markdown]
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a
+# `OneHotEncoder(categories=categories, sparse=False)` to force the use a
 # dense representation as a workaround.
 
 # %%

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -15,7 +15,7 @@
 # %% [markdown]
 # # 📃 Solution for Exercise 01
 #
-# The goal of this exercise is to evalutate the impact of using an arbitrary
+# The goal of this exercise is to evaluatte the impact of using an arbitrary
 # integer encoding for categorical variables along with a linear
 # classification model such as Logistic Regression.
 #
@@ -74,9 +74,13 @@ print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
 # %% [markdown]
-# Using an arbitrary mapping from string labels to integers as done here causes the linear model to make bad assumptions on the relative ordering of  categories.
+# Using an arbitrary mapping from string labels to integers as done here causes
+# the linear model to make bad assumptions on the relative ordering of
+# categories.
 #
-# This prevent the model to learning anything predictive enough and the cross-validated score is even lower that the baseline we obtained by ignoring the input data and just always predict the most frequent class:
+# This prevent the model to learning anything predictive enough and the
+# cross-validated score is even lower that the baseline we obtained by ignoring
+# the input data and just always predict the most frequent class:
 
 # %%
 from sklearn.dummy import DummyClassifier
@@ -87,15 +91,15 @@ print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
 # %% [markdown]
-# By comparison, a categorical encoding that does not assume any ordering in the
-# categories can lead to a significantly higher score:
+# By comparison, a categorical encoding that does not assume any ordering in
+# the categories can lead to a significantly higher score:
 
 # %%
 from sklearn.preprocessing import OneHotEncoder
 
 model = make_pipeline(
-    OneHotEncoder(handle_unknown="ignore"),
-    LogisticRegression(max_iter=1000))
+    OneHotEncoder(categories=categories, drop="if_binary"),
+    LogisticRegression())
 scores = cross_val_score(model, data_categorical, target)
 print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -15,7 +15,7 @@
 # %% [markdown]
 # # 📃 Solution for Exercise 01
 #
-# The goal of this exercise is to evaluatte the impact of using an arbitrary
+# The goal of this exercise is to evaluate the impact of using an arbitrary
 # integer encoding for categorical variables along with a linear
 # classification model such as Logistic Regression.
 #

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -68,9 +68,10 @@ categories = [
 # %%
 # %%time
 
+categorical_preprocessor = OrdinalEncoder(categories=categories)
 preprocessor = ColumnTransformer([
-    ('categorical', OrdinalEncoder(categories=categories),
-     categorical_columns),], remainder="passthrough")
+    ('categorical', categorical_preprocessor, categorical_columns)],
+    remainder="passthrough")
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
 scores = cross_val_score(model, data, target)
@@ -87,7 +88,7 @@ from sklearn.preprocessing import StandardScaler
 preprocessor = ColumnTransformer([
     ('numerical', StandardScaler(), numerical_columns),
     ('categorical', OrdinalEncoder(categories=categories),
-     categorical_columns),])
+     categorical_columns)])
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
 scores = cross_val_score(model, data, target)
@@ -117,29 +118,22 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
 # %% [markdown]
 # Reminder: in order to avoid creating fully correlated features it is
-# preferable to use a `OrdinalEncoder` for binary features (in this case `sex`)
-# rather than a `OneHotEncoder`.
-
-# %%
-binary_encoding_columns = ['sex']
-one_hot_encoding_columns = [
-    c for c in categorical_columns if c not in binary_encoding_columns]
+# preferable to use a `OneHotEncoder` with the option `drop="if_binary"`.
 
 # %% [markdown]
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a
+# `OneHotEncoder(categories=categories, sparse=False)` to force the use a
 # dense representation as a workaround.
 
 # %%
 # %%time
 from sklearn.preprocessing import OneHotEncoder
 
+categorical_preprocessor = OneHotEncoder(categories=categories,
+                                         sparse=False)
 preprocessor = ColumnTransformer([
-    ('binary-encoder', OrdinalEncoder(), binary_encoding_columns),
-    ('one-hot-encoder',
-     OneHotEncoder(handle_unknown="ignore", sparse=False),
-     one_hot_encoding_columns)],
+    ('one-hot-encoder', categorical_preprocessor, categorical_columns)],
     remainder="passthrough")
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -130,8 +130,8 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # %%time
 from sklearn.preprocessing import OneHotEncoder
 
-categorical_preprocessor = OneHotEncoder(categories=categories,
-                                         sparse=False)
+categorical_preprocessor = OneHotEncoder(
+    categories=categories, drop="if_binary", sparse=False)
 preprocessor = ColumnTransformer([
     ('one-hot-encoder', categorical_preprocessor, categorical_columns)],
     remainder="passthrough")

--- a/python_scripts/04_parameter_tuning.py
+++ b/python_scripts/04_parameter_tuning.py
@@ -70,9 +70,8 @@ categories = [
 categorical_preprocessor = OrdinalEncoder(categories=categories)
 
 preprocessor = ColumnTransformer([
-    ('cat-preprocessor', categorical_preprocessor,
-     categorical_columns),], remainder='passthrough',
-                                 sparse_threshold=0)
+    ('cat-preprocessor', categorical_preprocessor, categorical_columns)],
+    remainder='passthrough', sparse_threshold=0)
 
 # %% [markdown]
 # Finally, we use a tree-based classifier (i.e. histogram gradient-boosting) to

--- a/python_scripts/04_parameter_tuning_search.py
+++ b/python_scripts/04_parameter_tuning_search.py
@@ -66,9 +66,8 @@ categories = [
 categorical_preprocessor = OrdinalEncoder(categories=categories)
 
 preprocessor = ColumnTransformer([
-    ('cat-preprocessor', categorical_preprocessor,
-     categorical_columns),], remainder='passthrough',
-                                 sparse_threshold=0)
+    ('cat-preprocessor', categorical_preprocessor, categorical_columns)],
+    remainder='passthrough', sparse_threshold=0)
 
 # %% [markdown]
 # Finally, we use a tree-based classifier (i.e. histogram gradient-boosting) to

--- a/python_scripts/04_parameter_tuning_sol_02.py
+++ b/python_scripts/04_parameter_tuning_sol_02.py
@@ -58,6 +58,7 @@ categories = [data[column].unique()
 numerical_columns_selector = selector(dtype_exclude=object)
 numerical_columns = numerical_columns_selector(data)
 
+# %%
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import StandardScaler
 
@@ -98,9 +99,9 @@ model = make_pipeline(preprocessor, LogisticRegression())
 # data.
 #
 # Notes: some combinations of the hyper-parameters proposed above are invalid.
-# You can make the parameter search accept such failures by setting `error_score`
-# to `np.nan`. The warning messages give more details on which parameter
-# combinations but the computation will proceed.
+# You can make the parameter search accept such failures by setting
+# `error_score` to `np.nan`. The warning messages give more details on which
+# parameter combinations but the computation will proceed.
 #
 # Once the computation has completed, print the best combination of parameters
 # stored in the `best_params_` attribute.
@@ -128,8 +129,8 @@ model_random_search.best_params_
 # going to load the results obtained from a similar search with many more
 # iterations (200 instead of 20).
 #
-# This way we can have a more detailed plot while being able to run this notebook
-# in a reasonably short amount of time.
+# This way we can have a more detailed plot while being able to run this
+# notebook in a reasonably short amount of time.
 
 # %%
 # Uncomment this cell if you want to regenerate the results csv file. This

--- a/python_scripts/04_parameter_tuning_sol_02.py
+++ b/python_scripts/04_parameter_tuning_sol_02.py
@@ -62,7 +62,8 @@ numerical_columns = numerical_columns_selector(data)
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import StandardScaler
 
-categorical_processor = OneHotEncoder(categories=categories)
+categorical_processor = OneHotEncoder(categories=categories,
+                                      drop="if_binary")
 numerical_processor = StandardScaler()
 
 # %% [markdown]


### PR DESCRIPTION
close #120 

Specifying the columns in both `OrdinalEncoder` and `OneHotEncoder` for consistency.
Since we do so, we can use `drop="if_binary"` in `OneHotEncoder`.

I also make some small improvement regarding some description.

In the future:

* `OrdinalEncoder` will handle rare categories.
* `OneHotEncoding` should handle `handle_unknown="ignore"` as well as `drop="if_binary"`.