### PR TITLE
Pin nbformat to 5.0.8 to avoid regression.

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -26,7 +26,9 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install jupyter-book
-
+        # nbformat 5.1 adds random id which creates problems with jupyter-cache
+        # https://github.com/mwouts/jupytext/issues/715
+        pip install nbformat==5.0.8
     - name: Build the book
       run: |
         cd jupyter-book

--- a/build_tools/circle/build_jupyter_book.sh
+++ b/build_tools/circle/build_jupyter_book.sh
@@ -9,6 +9,9 @@ conda create -n testenv --yes pip python=3.7
 conda activate testenv
 pip install -r requirements.txt
 pip install jupyter-book
+# nbformat 5.1 adds random id which creates problems with jupyter-cache
+# https://github.com/mwouts/jupytext/issues/715
+pip install nbformat==5.0.8
 
 cd jupyter-book
 make 2>&1 | tee build.log


### PR DESCRIPTION
nbformat 5.1 adds random ids to cells which creates issues with jupyter-cache.

This manifests itself as cell outputs not being shown (e.g. `df.head()` output is blank below):
![image](https://user-images.githubusercontent.com/1680079/104724713-59690180-5731-11eb-8bf5-2ae886cc3104.png)

Warnings like:
```
WARNING: Notebook code has no file extension metadata, defaulting to `.txt`
WARNING: Couldn't find cache key for notebook file python_scripts/02_numerical_pipeline_ex_01.py. Outputs will not be inserted.
```

Thanks @Phaide for noticing!

This problem is mentioned here for example: https://github.com/mwouts/jupytext/issues/715