### PR TITLE
Tweak requirement files.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - scikit-learn >= 0.23.2
+  - scikit-learn >= 0.24
   - pandas >= 1
   - matplotlib-base
   - seaborn

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,4 @@ dependencies:
   - notebook
   - jupytext
   - plotly
-  - imblearn
+  - imbalanced-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ plotly
 jupyterlab
 notebook
 jupytext
-sphinxcontrib-bibtex==1.0  # 2.0 currently breaks jupyterbook
-imblearn
+imbalanced-learn


### PR DESCRIPTION
sphinxcontrib-bibtext problem has likely been fixed (originally a problem in 2.0.0 released in December 2020, many releases since).

imblearn does not exist in conda-forge, its name is imbalanced-learn. Use the same name for pip.