### PR TITLE
Unpin nbformat now after jupyter-cache 0.4.2 release.

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -26,9 +26,6 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install jupyter-book
-        # nbformat 5.1 adds random id which creates problems with jupyter-cache
-        # https://github.com/mwouts/jupytext/issues/715
-        pip install nbformat==5.0.8
     - name: Build the book
       run: |
         cd jupyter-book

--- a/build_tools/circle/build_jupyter_book.sh
+++ b/build_tools/circle/build_jupyter_book.sh
@@ -9,9 +9,6 @@ conda create -n testenv --yes pip python=3.7
 conda activate testenv
 pip install -r requirements.txt
 pip install jupyter-book
-# nbformat 5.1 adds random id which creates problems with jupyter-cache
-# https://github.com/mwouts/jupytext/issues/715
-pip install nbformat==5.0.8
 
 cd jupyter-book
 make 2>&1 | tee build.log


### PR DESCRIPTION
Fixed in https://github.com/executablebooks/jupyter-cache/pull/62 and 0.4.2 jupyter-cache release.

Reverts #155.

