### PR TITLE
Use CircleCI cache for jupyter-cache folder.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ jobs:
       - run: cat /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-{{ .Branch }}
-            - v1-master
+            - v2-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+            - v2-{{ .Branch }}
+            - v2-master
       - run:
           command: ./build_tools/circle/build_jupyter_book.sh
           no_output_timeout: 30m
@@ -31,7 +31,7 @@ jobs:
       - save_cache:
           paths:
             - jupyter-book/_build/.jupyter_cache
-          key: v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v2-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
       - store_artifacts:
           path: jupyter-book/_build/html
           destination: jupyter-book

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,21 @@ jobs:
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
+      - run: ./build_tools/circle/checksum_python_files.sh /tmp/checksum.txt
+      - run: cat /tmp/checksum.txt
+      - restore_cache:
+          keys:
+            - v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+            - v1-{{ .Branch }}
+            - v1-master
       - run:
           command: ./build_tools/circle/build_jupyter_book.sh
           no_output_timeout: 30m
+
+      - save_cache:
+          paths:
+            - ./jupyter-book/_build/.jupyter-cache
+          key: v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
       - store_artifacts:
           path: jupyter-book/_build/html
           destination: jupyter-book

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,13 @@ jobs:
       - run:
           command: ./build_tools/circle/build_jupyter_book.sh
           no_output_timeout: 30m
-
+      - run:
+          command: ls jupyter-book/_build/.jupyter_cache
+      - run:
+          command: du -sh jupyter-book/_build/.jupyter_cache
       - save_cache:
           paths:
-            - ./jupyter-book/_build/.jupyter-cache
+            - jupyter-book/_build/.jupyter_cache
           key: v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
       - store_artifacts:
           path: jupyter-book/_build/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,23 +15,18 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - run: ./build_tools/circle/checksum_python_files.sh /tmp/checksum.txt
-      - run: cat /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v2-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v2-{{ .Branch }}
-            - v2-master
+            - v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+            - v1-{{ .Branch }}
+            - v1-master
       - run:
           command: ./build_tools/circle/build_jupyter_book.sh
           no_output_timeout: 30m
-      - run:
-          command: ls jupyter-book/_build/.jupyter_cache
-      - run:
-          command: du -sh jupyter-book/_build/.jupyter_cache
       - save_cache:
           paths:
             - jupyter-book/_build/.jupyter_cache
-          key: v2-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
       - store_artifacts:
           path: jupyter-book/_build/html
           destination: jupyter-book

--- a/build_tools/circle/checksum_python_files.sh
+++ b/build_tools/circle/checksum_python_files.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+RESULT_FILE=$1
+
+if [ -f $RESULT_FILE ]; then
+    rm $RESULT_FILE
+fi
+touch $RESULT_FILE
+
+checksum_file() {
+    echo `openssl md5 $1 | awk '{print $2}'`
+}
+
+FILES=()
+while read -r -d ''; do
+	  FILES+=("$REPLY")
+done < <(find python_scripts -name '*.py' -type f -print0)
+
+# Loop through files and append MD5 to result file
+for FILE in ${FILES[@]}; do
+	  echo `checksum_file $FILE` >> $RESULT_FILE
+done
+
+# Sort the file so that it does not depend on the order of find
+sort $RESULT_FILE -o $RESULT_FILE
+


### PR DESCRIPTION
CircleCI only supports hashing a single file for the cache key. The `jupyter-cache` cache depends on all the `python_scripts` file so we use a script that creates a single file with the hashes of all the `python_scripts` files.

Idea was taken from:
- https://medium.com/@chrisbanes/circleci-cache-key-over-many-files-c9e07f4d471a
- https://github.com/chrisbanes/tivi/commit/c1219aeee9f62600fcd43d7caf1ea21e6e92930f