### PR TITLE
use cross-validation instead of single split

### DIFF
--- a/python_scripts/02_numerical_pipeline_hands_on.py
+++ b/python_scripts/02_numerical_pipeline_hands_on.py
@@ -198,9 +198,16 @@ accuracy = model.score(data_test, target_test)
 print(f"Accuracy of logistic regression: {accuracy:.3f}")
 
 # %% [markdown]
+#
+# ```{caution}
+# Be aware you should use cross-validation instead of `train_test_split` in
+# practice. We used a single split, to highlight the scikit-learn API and the
+# methods `fit`, `predict`, and `score`. In the module "Select the best model"
+# we will go into details regarding cross-validation.
+# ```
+#
 # Now the real question is: is this performance relevant of a good predictive
-# model?
-# Find out by solving the next exercise !.
+# model? Find out by solving the next exercise!.
 #
 # In this notebook, we learned:
 #

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -67,6 +67,15 @@ data_train, data_test, target_train, target_test = train_test_split(
     data_numeric, target, random_state=42)
 
 # %% [markdown]
+#
+# ```{caution}
+# Be aware that we are using a single train-test split instead of a
+# cross-validation to present the scikit-learn transformers API. We are not
+# interested in evaluating the statistical performance of the predictive model.
+# For this latest purpose, it would be required to evaluate via
+# cross-validation.
+# ```
+#
 # ## Model fitting without preprocessing
 #
 # We will use the logistic regression classifier as in the previous notebook.

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -285,9 +285,9 @@ print(f"The mean cross-validation accuracy is: "
 # the blue samples. Cross-validation is therefore computationally intensive
 # because it requires training several models instead of one.
 #
-# Note that the `cross_val_score` method above discards the 5 models that were
-# trained on the different overlapping subset of the dataset. The goal of
-# cross-validation is not to train a model, but rather to estimate
+# Note that by default the `cross_validate` function above discards the 5
+# models that were trained on the different overlapping subset of the dataset.
+# The goal of cross-validation is not to train a model, but rather to estimate
 # approximately the generalization performance of a model that would have been
 # trained to the full training set, along with an estimate of the variability
 # (uncertainty on the generalization accuracy).

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -233,19 +233,33 @@ print(f"The accuracy using a {model_name} is {score:.3f} "
 # "Selecting the best model".
 # ```
 #
-# The function `cross_val_score` allows for such experimental protocol by
-# giving the model, the data and the target. Since there exists several
-# cross-validation strategies, `cross_val_score` takes a parameter `cv` which
+# The function `cross_validate` allows for such experimental protocol by
+# providing the model, the data, and the target. Since there exists several
+# cross-validation strategies, `cross_validate` takes a parameter `cv` which
 # defines the splitting strategy.
 
 # %%
 # %%time
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import cross_validate
 
-scores = cross_val_score(model, data_numeric, target, cv=5)
-scores
+cv_result = cross_validate(model, data_numeric, target, cv=5)
+cv_result
+
+# %% [markdown]
+# The output of `cross_validate` contains by default three entries: (i) the
+# time to train the model on the training data for each fold, (ii) the time
+# to predict with the model on the testing data for each fold, and (iii) the
+# default score on the testing data for each fold.
+#
+# Additional can be returned, for instance training scores or the fitted models
+# per fold, by passing additional parameters. We will give more details about
+# these features in a subsequent notebook.
+#
+# Let's extract the test scores for the dictionary and compute the mean
+# accuracy and the variation of the accuracy across folds.
 
 # %%
+scores = cv_result["test_score"]
 print(f"The mean cross-validation accuracy is: "
       f"{scores.mean():.3f} +/- {scores.std():.3f}")
 

--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -305,11 +305,12 @@ model = make_pipeline(
 # columns.
 
 # %%
-from sklearn.model_selection import cross_val_score
-scores = cross_val_score(model, data_categorical, target)
-scores
+from sklearn.model_selection import cross_validate
+cv_results = cross_validate(model, data_categorical, target)
+cv_results
 
 # %%
+scores = cv_results["test_score"]
 print(f"The accuracy is: {scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -144,6 +144,12 @@ data_train, data_test, target_train, target_test = train_test_split(
     data, target, random_state=42)
 
 # %% [markdown]
+#
+# ```{caution}
+# Be aware that we use `train_test_split` here for didactic purposes, to show
+# the scikit-learn API.
+# ```
+#
 # Now, we can train the model on the train set.
 
 # %%
@@ -180,12 +186,13 @@ model.score(data_test, target_test)
 # scikit-learn as any other predictors:
 
 # %%
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import cross_validate
 
-scores = cross_val_score(model, data, target, cv=5)
-scores
+cv_results = cross_validate(model, data, target, cv=5)
+cv_results
 
 # %%
+scores = cv_results["test_score"]
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
 # %% [markdown]

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -56,7 +56,7 @@ categorical_columns = categorical_columns_selector(data)
 data_categorical = data[categorical_columns]
 
 # %%
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import cross_validate
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OrdinalEncoder
 from sklearn.linear_model import LogisticRegression

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -63,7 +63,7 @@ categories = [
 
 # %%
 # %%time
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import cross_validate
 from sklearn.pipeline import make_pipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OrdinalEncoder
@@ -76,7 +76,8 @@ preprocessor = ColumnTransformer([
     remainder="passthrough")
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
-scores = cross_val_score(model, data, target)
+cv_results = cross_validate(model, data, target)
+scores = cv_results["test_score"]
 print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -70,7 +70,7 @@ categories
 # ordinal encoder before to feed a logistic regression.
 
 # %%
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import cross_validate
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OrdinalEncoder
 from sklearn.linear_model import LogisticRegression
@@ -78,7 +78,8 @@ from sklearn.linear_model import LogisticRegression
 model = make_pipeline(
     OrdinalEncoder(categories=categories),
     LogisticRegression(max_iter=500))
-scores = cross_val_score(model, data_categorical, target)
+cv_results = cross_validate(model, data_categorical, target)
+scores = cv_results["test_score"]
 print(f"The different scores obtained are: \n{scores}")
 
 # %%
@@ -96,8 +97,9 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # %%
 from sklearn.dummy import DummyClassifier
 
-scores = cross_val_score(DummyClassifier(strategy="most_frequent"),
-                         data_categorical, target)
+cv_results = cross_validate(DummyClassifier(strategy="most_frequent"),
+                            data_categorical, target)
+scores = cv_results["test_score"]
 print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
@@ -111,6 +113,7 @@ from sklearn.preprocessing import OneHotEncoder
 model = make_pipeline(
     OneHotEncoder(categories=categories, drop="if_binary"),
     LogisticRegression(max_iter=500))
-scores = cross_val_score(model, data_categorical, target)
+cv_results = cross_validate(model, data_categorical, target)
+scores = cv_results["test_score"]
 print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -59,7 +59,7 @@ categories = [
 
 # %%
 # %%time
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import cross_validate
 from sklearn.pipeline import make_pipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OrdinalEncoder
@@ -72,7 +72,8 @@ preprocessor = ColumnTransformer([
     remainder="passthrough")
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
-scores = cross_val_score(model, data, target)
+cv_results = cross_validate(model, data, target)
+scores = cv_results["test_score"]
 print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
@@ -89,7 +90,8 @@ preprocessor = ColumnTransformer([
      categorical_columns)])
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
-scores = cross_val_score(model, data, target)
+cv_results = cross_validate(model, data, target)
+scores = cv_results["test_score"]
 print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 
@@ -132,7 +134,8 @@ preprocessor = ColumnTransformer([
     remainder="passthrough")
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
-scores = cross_val_score(model, data, target)
+cv_results = cross_validate(model, data, target)
+scores = cv_results["test_score"]
 print(f"The different scores obtained are: \n{scores}")
 print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 

--- a/python_scripts/cross_validation_train_test.py
+++ b/python_scripts/cross_validation_train_test.py
@@ -52,7 +52,7 @@ y.head()
 # %%
 from sklearn.tree import DecisionTreeRegressor
 
-regressor = DecisionTreeRegressor()
+regressor = DecisionTreeRegressor(random_state=0)
 regressor.fit(X, y)
 
 # %% [markdown]
@@ -232,7 +232,7 @@ print(f"The standard deviation of the generalization error is: "
 # %% [markdown]
 # Note that the standard deviation is much smaller than the mean: we could
 # summarize that our cross-validation estimate of the generalization error is
-# 45.7 +/- 1.1 k\$.
+# 45.88 +/- 1.00 k\$.
 #
 # If we were to train a single model on the full dataset (without
 # cross-validation) and then had later access to an unlimited amount of test
@@ -276,6 +276,33 @@ print(f"The standard deviation of the target is: {y.std():.2f} k$")
 # But in all cases, an error of 45 k\$ might be too large to automatically use
 # our model to tag house value without expert supervision.
 #
+# ## More detail regarding `cross_validate`
+#
+# During cross-validation, many models are trained and evaluated. Indeed, the
+# number of elements in each array of the output of `cross_validate` is a
+# result from one of this `fit`/`score`. To make it explicit, it is possible
+# to retrieve theses fitted models for each of the fold by passing the option
+# `return_estimator=True` in `cross_validate`.
+
+# %%
+cv_results = cross_validate(regressor, X, y, return_estimator=True)
+cv_results
+
+# %%
+cv_results["estimator"]
+
+# %% [markdown]
+# The five decision tree regressors corresponds to the five fitted decision
+# trees on the different folds. Having access to these regressors is handy
+# because it allows to inspect the internal fitted parameters of these
+# regressors.
+#
+# In the case where you are interested only about the test score, scikit-learn
+# provide a `cross_val_score` function. It is identical to calling the
+# `cross_validate` function and to select the `test_score` only (as we
+# extensively did in the previous notebooks).
+
+# %% [markdown]
 # ## Summary
 #
 # In this notebook, we saw:

--- a/python_scripts/cross_validation_train_test.py
+++ b/python_scripts/cross_validation_train_test.py
@@ -302,6 +302,12 @@ cv_results["estimator"]
 # `cross_validate` function and to select the `test_score` only (as we
 # extensively did in the previous notebooks).
 
+# %%
+from sklearn.model_selection import cross_val_score
+
+scores = cross_val_score(regressor, X, y)
+scores
+
 # %% [markdown]
 # ## Summary
 #

--- a/python_scripts/ensemble_gradient_boosting.py
+++ b/python_scripts/ensemble_gradient_boosting.py
@@ -16,7 +16,6 @@
 # machinery.
 
 # %%
-# %%
 import pandas as pd
 import numpy as np
 
@@ -215,54 +214,48 @@ print(f"Error of the tree: {y_true - y_pred_first_and_second_tree:.3f}")
 
 # %%
 from sklearn.datasets import fetch_california_housing
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import cross_validate
 
 X, y = fetch_california_housing(return_X_y=True, as_frame=True)
-X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
 # %%
-from time import time
 from sklearn.ensemble import GradientBoostingRegressor
 
 gradient_boosting = GradientBoostingRegressor(n_estimators=200)
+cv_results_gbdt = cross_validate(gradient_boosting, X, y, n_jobs=-1)
 
-start_time = time()
-gradient_boosting.fit(X_train, y_train)
-fit_time_gradient_boosting = time() - start_time
-
-start_time = time()
-score_gradient_boosting = gradient_boosting.score(X_test, y_test)
-score_time_gradient_boosting = time() - start_time
-
-print("Gradient boosting decision tree")
-print(f"R2 score: {score_gradient_boosting:.3f}")
-print(f"Fit time: {fit_time_gradient_boosting:.2f} s")
-print(f"Score time: {score_time_gradient_boosting:.5f} s\n")
+# %%
+print("Gradient Boosting Decision Tree")
+print(f"R2 score via cross-validation: "
+      f"{cv_results_gbdt['test_score'].mean():.3f} +/- "
+      f"{cv_results_gbdt['test_score'].std():.3f}")
+print(f"Average fit time: "
+      f"{cv_results_gbdt['fit_time'].mean():.3f} seconds")
+print(f"Average score time: "
+      f"{cv_results_gbdt['score_time'].mean():.3f} seconds")
 
 # %%
 from sklearn.ensemble import RandomForestRegressor
 
 random_forest = RandomForestRegressor(n_estimators=200, n_jobs=-1)
+cv_results_rf = cross_validate(gradient_boosting, X, y, n_jobs=-1)
 
-start_time = time()
-random_forest.fit(X_train, y_train)
-fit_time_random_forest = time() - start_time
-
-start_time = time()
-score_random_forest = random_forest.score(X_test, y_test)
-score_time_random_forest = time() - start_time
-
-print("Random forest")
-print(f"R2 score: {score_random_forest:.3f}")
-print(f"Fit time: {fit_time_random_forest:.2f} s")
-print(f"Score time: {score_time_random_forest:.5f} s")
+# %%
+print("Random Forest")
+print(f"R2 score via cross-validation: "
+      f"{cv_results_rf['test_score'].mean():.3f} +/- "
+      f"{cv_results_rf['test_score'].std():.3f}")
+print(f"Average fit time: "
+      f"{cv_results_rf['fit_time'].mean():.3f} seconds")
+print(f"Average score time: "
+      f"{cv_results_rf['score_time'].mean():.3f} seconds")
 
 # %% [markdown]
 # In term of computation performance, the forest can be parallelized and will
-# benefit from using multiple cores. In terms of scoring performance, both
-# algorithms lead to very close results.
+# benefit from using multiple cores of the CPU. In terms of scoring
+# performance, both algorithms lead to very close results.
 #
-# However, we can observe that the gradient boosting is a very fast algorithm
-# to predict compared to random forest. This is due to the fact that gradient
+# However, we see that the gradient boosting is a very fast algorithm to
+# predict compared to random forest. This is due to the fact that gradient
 # boosting uses shallow trees. We will go into details in the next notebook
-# about the tree parametrization.
+# about the hyperparameters to consider when optimizing ensemble methods.

--- a/python_scripts/ensemble_hyperparameters.py
+++ b/python_scripts/ensemble_hyperparameters.py
@@ -9,6 +9,12 @@
 # hyperparameters of both random forest and gradient boosting decision tree
 # models.
 #
+# ```{caution}
+# For the sake of clarity, no cross-validation will be used to estimate the
+# generalization error. We are only showing the effect of the parameters
+# on the validation set of what should be the inner cross-validation.
+# ```
+#
 # ## Random forest
 #
 # The main parameter to tune for random forest is the `n_estimators`

--- a/python_scripts/ensemble_introduction.py
+++ b/python_scripts/ensemble_introduction.py
@@ -15,24 +15,19 @@ from sklearn.datasets import fetch_california_housing
 X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 
 # %% [markdown]
-# As usual, we divide our dataset into training and a testing sets.
+# We will check the performance of decision tree regressor with default
+# parameters.
 
 # %%
-from sklearn.model_selection import train_test_split
-
-X_train, X_test, y_train, y_test = train_test_split(
-    X, y, random_state=0, test_size=0.5)
-
-# %% [markdown]
-# We will train a decision tree regressor and check its performance.
-
-# %%
+from sklearn.model_selection import cross_validate
 from sklearn.tree import DecisionTreeRegressor
 
-tree = DecisionTreeRegressor()
-tree.fit(X_train, y_train)
-print(f"R2 score of the default tree:\n"
-      f"{tree.score(X_test, y_test):.3f}")
+tree = DecisionTreeRegressor(random_state=0)
+cv_results = cross_validate(tree, X, y, n_jobs=-1)
+scores = cv_results["test_score"]
+
+print(f"R2 score obtained by cross-validation: "
+      f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
 # We obtain fair results. However, as we previously presented in the "tree in
@@ -51,63 +46,32 @@ print(f"R2 score of the default tree:\n"
 # earlier.
 
 # %%
+# %%time
 from sklearn.model_selection import GridSearchCV
 from sklearn.tree import DecisionTreeRegressor
 
 param_grid = {
-    "max_depth": [3, 5, 8, None],
+    "max_depth": [5, 8, None],
     "min_samples_split": [2, 10, 30, 50],
     "min_samples_leaf": [0.01, 0.05, 0.1, 1]}
 cv = 3
 
 tree = GridSearchCV(DecisionTreeRegressor(random_state=0),
                     param_grid=param_grid, cv=cv, n_jobs=-1)
-_ = tree.fit(X_train, y_train)
+cv_results = cross_validate(tree, X, y, n_jobs=-1, return_estimator=True)
+scores = cv_results["test_score"]
+
+print(f"R2 score obtained by cross-validation: "
+      f"{scores.mean():.3f} +/- {scores.std():.3f}")
+
+# %% [markdown]
+# We see that optimizing the hyperparameters will have a positive effect
+# on the statistical performance. However, it comes with a higher computational
+# cost.
 
 # %% [markdown]
 # We can create a dataframe storing the important information collected during
 # the tuning of the parameters and investigate the results.
-
-# %%
-import pandas as pd
-
-cv_results = pd.DataFrame(tree.cv_results_)
-interesting_columns = [
-    "param_max_depth",
-    "param_min_samples_split",
-    "param_min_samples_leaf",
-    "mean_test_score",
-    "rank_test_score",
-    "mean_fit_time",
-]
-
-cv_results = cv_results[interesting_columns].sort_values(by="rank_test_score")
-cv_results
-
-# %% [markdown]
-# From theses results, we can see that the best parameters is the combination
-# where the depth of the tree is not limited and the minimum number of samples
-# to create a leaf is also equal to 1 (the default values) and the
-# minimum number of samples to make a split of 50 (much higher than the default
-# value).
-#
-# It is interesting to look at the total amount of time it took to fit all
-# these different models. In addition, we can check the performance of the
-# optimal decision tree on the left-out testing data.
-
-# %%
-total_fitting_time = (cv_results["mean_fit_time"] * cv).sum()
-print(f"Required training time of the GridSearchCV: "
-      f"{total_fitting_time:.2f} seconds")
-print(f"Best R2 score of a single tree: {tree.best_score_:.3f}")
-
-# %% [markdown]
-# Hence, we have a model that has an $R^2$ score below 0.7. So this model is
-# better than the previous default decision tree.
-#
-# However, the amount of time to find the best learner has an heavy
-# computational cost. Indeed, it depends on the number of folds used during the
-# cross-validation in the grid-search multiplied by the number of parameters.
 #
 # Now we will use an ensemble method called bagging. More details about this
 # method will be discussed in the next section. In short, this method will use
@@ -120,27 +84,28 @@ print(f"Best R2 score of a single tree: {tree.best_score_:.3f}")
 # we are not going to tune any parameter of the decision tree.
 
 # %%
-from time import time
+# %%time
 from sklearn.ensemble import BaggingRegressor
 
 base_estimator = DecisionTreeRegressor(random_state=0)
 bagging_regressor = BaggingRegressor(
-    base_estimator=base_estimator, n_estimators=50, random_state=0)
+    base_estimator=base_estimator, n_estimators=20, random_state=0)
 
-start_fitting_time = time()
-bagging_regressor.fit(X_train, y_train)
-elapsed_fitting_time = time() - start_fitting_time
+cv_results = cross_validate(bagging_regressor, X, y, n_jobs=-1)
+scores = cv_results["test_score"]
 
-print(f"Elapsed fitting time: {elapsed_fitting_time:.2f} seconds")
-print(f"R2 score: {bagging_regressor.score(X_test, y_test):.3f}")
+print(f"R2 score obtained by cross-validation: "
+      f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
-# We can see that the computation time is much shorter for training the full
-# ensemble than for the parameter search of a single tree. In addition, the
-# score is significantly improved with a $R^2$ close to 0.8. Furthermore, note
-# that this result is obtained before any parameter tuning. This shows the
-# motivation behind the use of an ensemble learner: it gives a relatively good
-# baseline with decent performance without any parameter tuning.
+# Without searching for optimal hyperparameters, the overall statistical
+# performance of the bagging regressor is better than a single decision tree.
+# In addition, the computational cost is reduced in comparison of seeking
+# for the optimal hyperparameters.
+#
+# This shows the motivation behind the use of an ensemble learner: it gives a
+# relatively good baseline with decent performance without any parameter
+# tuning.
 #
 # Now, we will discuss in detail two ensemble families: bagging and
 # boosting:

--- a/python_scripts/ensemble_random_forest.py
+++ b/python_scripts/ensemble_random_forest.py
@@ -4,11 +4,11 @@
 # In this notebook, we will present the random forest models and
 # show the differences with the bagging classifiers.
 #
-# Random forests are a popular model in machine learning. They are a modification
-# of the bagging algorithm. In bagging, any classifier or regressor can be used.
-# In random forests, the base classifier or regressor must be a decision tree.
-# In our previous example, we used a decision tree but we could have used a
-# linear model as the regressor for our bagging algorithm.
+# Random forests are a popular model in machine learning. They are a
+# modification of the bagging algorithm. In bagging, any classifier or
+# regressor can be used. In random forests, the base classifier or regressor
+# must be a decision tree. In our previous example, we used a decision tree but
+# we could have used a linear model as the regressor for our bagging algorithm.
 #
 # In addition, random forests are different from bagging when used with
 # classifiers: when searching for the best split, only a subset of the original
@@ -21,7 +21,6 @@
 
 # %%
 from sklearn.datasets import fetch_california_housing
-from sklearn.model_selection import train_test_split
 
 X, y = fetch_california_housing(return_X_y=True, as_frame=True)
 

--- a/python_scripts/ensemble_random_forest.py
+++ b/python_scripts/ensemble_random_forest.py
@@ -24,10 +24,9 @@ from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
 
 X, y = fetch_california_housing(return_X_y=True, as_frame=True)
-X_train, X_test, y_train, y_test = train_test_split(
-    X, y, random_state=0, test_size=0.5)
 
 # %%
+from sklearn.model_selection import cross_val_score
 from sklearn.ensemble import BaggingRegressor
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.ensemble import RandomForestRegressor
@@ -37,15 +36,16 @@ random_forest = RandomForestRegressor(n_estimators=100, random_state=0,
 
 tree = DecisionTreeRegressor(random_state=0)
 bagging = BaggingRegressor(base_estimator=tree, n_estimators=100,
-                           n_jobs=-1,)
+                           n_jobs=-1)
 
-random_forest.fit(X_train, y_train)
-bagging.fit(X_train, y_train)
+scores_random_forest = cross_val_score(random_forest, X, y)
+scores_bagging = cross_val_score(bagging, X, y)
 
 print(f"Performance of random forest: "
-      f"{random_forest.score(X_test, y_test):.3f}")
+      f"{scores_random_forest.mean():.3f} +/- "
+      f"{scores_random_forest.std():.3f}")
 print(f"Performance of bagging: "
-      f"{bagging.score(X_test, y_test):.3f}")
+      f"{scores_bagging.mean():.3f} +/- {scores_bagging.std():.3f}")
 
 # %% [markdown]
 # Notice that we don't need to provide a `base_estimator` parameter to

--- a/python_scripts/linear_models_ex_03.py
+++ b/python_scripts/linear_models_ex_03.py
@@ -23,10 +23,12 @@ X.head()
 # %% [markdown]
 # Now this is your turn to train a linear regression model on this dataset.
 # You will need to:
-# * split the dataset into a training and testing set;
-# * train a linear regression model on the training set;
-# * compute the mean absolute error in thousands of dollars (k$);
-# * show the values of the coefficients for each feature.
+# * create a linear regression model;
+# * execute a cross-validation with 10 folds and use the mean absolute error
+#   (MAE) as metric. Ensure to return the fitted estimators;
+# * compute mean and std of the MAE in thousands of dollars (k$);
+# * show the values of the coefficients for each feature using a boxplot by
+#   inspecting the fitted model returned from the cross-validation.
 
 # %%
 # Write your code here.: make the exercise

--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -22,16 +22,6 @@ X, y = fetch_california_housing(as_frame=True, return_X_y=True)
 X.head()
 
 # %% [markdown]
-# As in the previous exercise, we will use an independent test set to evaluate
-# the performance of our model.
-
-# %%
-from sklearn.model_selection import train_test_split
-
-X_train, X_test, y_train, y_test = train_test_split(
-    X, y, random_state=0, test_size=0.5)
-
-# %% [markdown]
 # In one of the previous notebook, we showed that linear models could be used
 # even in settings where `X` and `y` are not linearly linked.
 #
@@ -44,17 +34,19 @@ X_train, X_test, y_train, y_test = train_test_split(
 # generalization capabilities of our model.
 
 # %%
+from sklearn.model_selection import cross_validate
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import PolynomialFeatures
 from sklearn.linear_model import LinearRegression
 
 linear_regression = make_pipeline(PolynomialFeatures(degree=2),
                                   LinearRegression())
-linear_regression.fit(X_train, y_train)
-test_score = linear_regression.score(X_test, y_test)
-
+cv_results = cross_validate(linear_regression, X, y, cv=10,
+                            return_train_score=True,
+                            return_estimator=True)
+test_score = cv_results["test_score"]
 print(f"R2 score of linear regresion model on the test set:\n"
-      f"{test_score:.3f}")
+      f"{test_score.mean():.3f} +/- {test_score.std():.3f}")
 
 # %% [markdown]
 # We see that we obtain an $R^2$ score below zero.
@@ -64,9 +56,9 @@ print(f"R2 score of linear regresion model on the test set:\n"
 # We can compute the score on the training set to confirm this intuition.
 
 # %%
-train_score = linear_regression.score(X_train, y_train)
+train_score = cv_results["train_score"]
 print(f"R2 score of linear regresion model on the train set:\n"
-      f"{train_score:.3f}")
+      f"{train_score.mean():.3f} +/- {train_score.std():.3f}")
 
 # %% [markdown]
 # The score on the training set is much better. This performance gap between
@@ -84,34 +76,46 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 sns.set_context("talk")
 
-weights_linear_regression = pd.Series(
-    linear_regression[-1].coef_,
-    index=linear_regression[0].get_feature_names(input_features=X.columns))
+# Define the style in the boxplot
+boxplot_property = {
+    "vert": False, "whis": 100, "patch_artist": True, "widths": 0.3,
+    "boxprops": dict(linewidth=3, color='black', alpha=0.9),
+    "medianprops": dict(linewidth=2.5, color='black', alpha=0.9),
+    "whiskerprops": dict(linewidth=3, color='black', alpha=0.9),
+    "capprops": dict(linewidth=3, color='black', alpha=0.9),
+}
+
+# %%
+weights_linear_regression = pd.DataFrame(
+    [est[-1].coef_ for est in cv_results["estimator"]],
+    columns=cv_results["estimator"][0][0].get_feature_names(
+        input_features=X.columns))
 _, ax = plt.subplots(figsize=(6, 16))
-_ = weights_linear_regression.plot(kind="barh", ax=ax)
+weights_linear_regression.plot.box(ax=ax, **boxplot_property)
+ax.set_title("Linear regression coefficients")
 
 # %% [markdown]
 # We can force the linear regression model to consider all features in a more
 # homogeneous manner. In fact, we could force large positive or negative weight
 # to shrink toward zero. This is known as regularization. We will use a ridge
-# model which enforces such behaviour.
+# model which enforces such behavior.
 
 # %%
 from sklearn.linear_model import Ridge
 
 ridge = make_pipeline(PolynomialFeatures(degree=2),
-                      Ridge(alpha=0.5))
-ridge.fit(X_train, y_train)
-
-# %%
-train_score = ridge.score(X_train, y_train)
-print(f"R2 score of ridge model on the train set:\n"
-      f"{train_score:.3f}")
-
-# %%
-test_score = ridge.score(X_test, y_test)
+                      Ridge(alpha=100))
+cv_results = cross_validate(ridge, X, y, cv=10,
+                            return_train_score=True,
+                            return_estimator=True)
+test_score = cv_results["test_score"]
 print(f"R2 score of ridge model on the test set:\n"
-      f"{test_score:.3f}")
+      f"{test_score.mean():.3f} +/- {test_score.std():.3f}")
+
+# %%
+train_score = cv_results["train_score"]
+print(f"R2 score of ridge model on the train set:\n"
+      f"{train_score.mean():.3f} +/- {train_score.std():.3f}")
 
 # %% [markdown]
 # We see that the training and testing scores are much closer, indicating that
@@ -119,17 +123,18 @@ print(f"R2 score of ridge model on the test set:\n"
 # ridge with the un-regularized linear regression.
 
 # %%
-weights_ridge = pd.Series(
-    ridge[-1].coef_,
-    index=ridge[0].get_feature_names(input_features=X.columns))
+weights_ridge = pd.DataFrame(
+    [est[-1].coef_ for est in cv_results["estimator"]],
+    columns=cv_results["estimator"][0][0].get_feature_names(
+        input_features=X.columns))
 
 # %%
-weights = pd.concat(
-    [weights_linear_regression, weights_ridge], axis=1,
-    keys=["Linear regression", "Ridge"])
-
-_, ax = plt.subplots(figsize=(6, 16))
-weights.plot(kind="barh", ax=ax)
+_, axs = plt.subplots(ncols=2, figsize=(12, 16))
+weights_linear_regression.plot.box(ax=axs[0], **boxplot_property)
+weights_ridge.plot.box(ax=axs[1], **boxplot_property)
+axs[1].set_yticklabels([""] * len(weights_ridge.columns))
+axs[0].set_title("Linear regression weights")
+_ = axs[1].set_title("Ridge weights")
 
 # %% [markdown]
 # We see that the magnitude of the weights are shrunk towards zero in
@@ -150,101 +155,47 @@ weights.plot(kind="barh", ax=ax)
 # This procedure should make us think about feature rescaling.
 # Let's consider the case where features have an identical data dispersion:
 # if two features are found equally important by the model, they will be
-# affected close weights in term of norm.
+# affected similarly by regularization strength.
 #
 # Now, let's consider the scenario where features have completely different
-# data dispersion (e.g. age in years and annual revenue in dollars).
+# data dispersion (for instance age in years and annual revenue in dollars).
 # If two features are as important, our model will boost the weights of
 # features with small dispersion and reduce the weights of features with
 # high dispersion.
 #
-# We recall that regularization forces weights to be closer.
+# We recall that regularization forces weights to be closer. Therefore, we get
+# an intuition that if we want to use regularization, dealing with rescaled
+# data would make it easier to find an optimal regularization parameter and
+# thus an adequate model.
 #
-# Therefore, we get an intuition that if we want to use regularization, dealing
-# with rescaled data would make it easier to find an optimal regularization
-# parameter and thus an adequate model.
+# As a side note, some solvers based on gradient computation are expecting such
+# rescaled data. Unscaled data will be detrimental when computing the optimal
+# weights. Therefore, when working with a linear model and numerical data, it
+# is generally good practice to scale the data.
 #
-# As a side note, some solvers based on gradient # computation are expecting
-# such rescaled data.
-# Unscaled data will be detrimental when computing the optimal weights.
-#
-# Therefore, when working with a linear model and numerical data,
-# it is generally good practice to scale the data.
-#
-# In the remaining of this section, we will present the basics on how to
-# incorporate a scaler within your machine learning pipeline.
-#
-# Scikit-learn provides several tools to preprocess the data, such as
-# the `StandardScaler`, which transforms the data in order for each feature
-# to have a mean of zero and a standard deviation of 1.
+# Thus, we will add a `StandardScaler` in the machine learning pipeline. This
+# scaler will be placed just before the regressor.
 
 # %%
 from sklearn.preprocessing import StandardScaler
 
-scaler = StandardScaler()
-X_train_scaled = scaler.fit(X_train).transform(X_train)
-X_test_scaled = scaler.transform(X_test)
-
-# %% [markdown]
-# This scikit-learn estimator is known as a transformer: it computes some
-# statistics (i.e the mean and the standard deviation) and stores them as
-# attributes (`scaler.mean_`, `scaler.scale_`) when calling `fit`. Using these
-# stats, it transforms the data when `transform` is called. Therefore, it
-# is important to note that `fit` should only be called on the training data,
-# similar to classifiers and regressors.
-
-# %%
-print('mean records on the training set:\n', scaler.mean_)
-print('standard deviation records on the training set:\n', scaler.scale_)
-
-# %% [markdown]
-# In the example above, `X_train_scaled` is the data scaled, using the
-# mean and standard deviation of each feature, computed using the training
-# data `X_train`.
-#
-# Thus, we can use these scaled dataset to train and test our model.
-
-# %%
-ridge.fit(X_train_scaled, y_train)
-test_score = ridge.score(X_test_scaled, y_test)
-
-print(f"R2 score of ridge model on the test set:\n"
-      f"{test_score:.3f}")
-
-# %% [markdown]
-# Instead of calling the transformer to transform the data and then calling the
-# regressor, scikit-learn provides a `Pipeline`, which 'chains' the transformer
-# and regressor together. The pipeline allows you to use a sequence of
-# transformer(s) followed by a regressor or a classifier, in one call. (i.e.
-# fitting the pipeline will fit both the transformer(s) and the regressor. Then
-# predicting from the pipeline will first transform the data through the
-# transformer(s) then predict with the regressor from the transformed data)
-#
-# This pipeline exposes the same API as the regressor and classifier and will
-# manage the calls to `fit` and `transform` for you, avoiding any problems with
-# data leakage (when knowledge of the test data was inadvertently included in
-# training a model, as when fitting a transformer on the test data).
-#
-# We already used `Pipeline` to create the polynomial features before training
-# the model.
-#
-# We will can create a new one by using `make_pipeline` and giving as
-# arguments the transformation(s) to be performed (in order) and the regressor
-# model.
-#
-# Here, we can implement the scaling process before training our model:
-
-# %%
 ridge = make_pipeline(PolynomialFeatures(degree=2), StandardScaler(),
                       Ridge(alpha=0.5))
-ridge.fit(X_train, y_train)
-test_score = ridge.score(X_test, y_test)
-
+cv_results = cross_validate(ridge, X, y, cv=10,
+                            return_train_score=True,
+                            return_estimator=True)
+test_score = cv_results["test_score"]
 print(f"R2 score of ridge model on the test set:\n"
-      f"{test_score:.3f}")
+      f"{test_score.mean():.3f} +/- {test_score.std():.3f}")
+
+# %%
+train_score = cv_results["train_score"]
+print(f"R2 score of ridge model on the train set:\n"
+      f"{train_score.mean():.3f} +/- {train_score.std():.3f}")
 
 # %% [markdown]
-# As we can see in this example, using a pipeline simplifies the manual handling.
+# As we can see in this example, using a pipeline simplifies the manual
+# handling.
 #
 # When creating the model, keeping the same `alpha` does not give good results.
 # It depends on the data provided. Therefore, it needs to be tuned for each
@@ -258,59 +209,43 @@ print(f"R2 score of ridge model on the test set:\n"
 # The default parameter will not lead to the optimal model. Therefore, we need
 # to tune the `alpha` parameter.
 #
-# Model hyperparameters tuning should be done with care. Indeed, we want to find
-# an optimal parameter that maximizes some metrics.
-# Thus, it requires both a training set and testing set.
+# Model hyperparameters tuning should be done with care. Indeed, we want to
+# find an optimal parameter that maximizes some metrics. Thus, it requires both
+# a training set and testing set.
 #
-# However, this testing set should be different from the out-of-sample testing set
-# that we used to evaluate our model:
-# if we use the same one, we are using an `alpha` which was optimized for
-# this testing set and it breaks the out-of-sample rule.
+# However, this testing set should be different from the out-of-sample testing
+# set that we used to evaluate our model: if we use the same one, we are using
+# an `alpha` which was optimized for this testing set and it breaks the
+# out-of-sample rule.
 #
-# Therefore, we can split our previous training set into two subsets: a
-# new training set and a validation set which we will use later to pick
-# the optimal value for `alpha`.
-
-# %%
-X_sub_train, X_valid, y_sub_train, y_valid = train_test_split(
-    X_train, y_train, random_state=0, test_size=0.25)
+# Therefore, we should include search of the hyperparameter `alpha` within the
+# cross-validation. As we saw in previous notebooks, we could use a
+# grid-search. However, some predictor in scikit-learn are available with
+# an integrated hyperparameter search, more efficient than using a grid-search.
+# The name of these predictors finishes by `CV`. In the case of `Ridge`,
+# scikit-learn provides a `RidgeCV` regressor.
+#
+# Therefore, we can use this predictor as the last step of the pipeline.
+# Including the pipeline a cross-validation allows to make a nested
+# cross-validation: the inner cross-validation will search for the best
+# alpha, while the outer cross-validation will give an estimate of the
+# generalization score.
 
 # %%
 import numpy as np
+from sklearn.linear_model import RidgeCV
 
 alphas = np.logspace(-10, -1, num=30)
-list_ridge_scores = []
-for alpha in alphas:
-    ridge.set_params(ridge__alpha=alpha)
-    ridge.fit(X_sub_train, y_sub_train)
-    list_ridge_scores.append(ridge.score(X_valid, y_valid))
-
-# %%
-plt.plot(alphas, list_ridge_scores, "+-", label='Ridge')
-plt.xlabel('alpha (regularization strength)')
-plt.ylabel('R2 score (higher is better)')
-_ = plt.legend()
-
-# %% [markdown]
-# As we can see, regularization is just like salt in cooking:
-# one must balance its amount to get the best performance.
-
-# %%
-best_alpha = alphas[np.argmax(list_ridge_scores)]
-best_alpha
-
-# %% [markdown]
-# Finally, we can re-train a Ridge model on the full dataset,
-# with the best value for alpha we found earlier, and check the score.
-
-# %%
 ridge = make_pipeline(PolynomialFeatures(degree=2), StandardScaler(),
-                      Ridge(alpha=best_alpha))
-ridge.fit(X_train, y_train)
-test_score = ridge.score(X_test, y_test)
+                      RidgeCV(store_cv_values=True))
 
-print(f"R2 score of ridge model on the test set:\n"
-      f"{test_score:.3f}")
+# %%
+cv_results = cross_validate(ridge, X, y, cv=10,
+                            return_train_score=True,
+                            return_estimator=True)
+test_score = cv_results["test_score"]
+print(f"R2 score of ridge model with optimal alpha on the test set:\n"
+      f"{test_score.mean():.3f} +/- {test_score.std():.3f}")
 
 # %% [markdown]
 # In the next exercise, you will use a scikit-learn estimator which allows to

--- a/python_scripts/linear_models_sol_03.py
+++ b/python_scripts/linear_models_sol_03.py
@@ -23,30 +23,31 @@ X.head()
 # %% [markdown]
 # Now this is your turn to train a linear regression model on this dataset.
 # You will need to:
-# * split the dataset into a training and testing set;
-# * train a linear regression model on the training set;
-# * compute the mean absolute error in thousands of dollars (k$);
-# * show the values of the coefficients for each feature.
-
-# %%
-from sklearn.model_selection import train_test_split
-
-X_train, X_test, y_train, y_test = train_test_split(
-    X, y, random_state=0
-)
+# * create a linear regression model;
+# * execute a cross-validation with 10 folds and use the mean absolute error
+#   (MAE) as metric. Ensure to return the fitted estimators;
+# * compute mean and std of the MAE in thousands of dollars (k$);
+# * show the values of the coefficients for each feature using a boxplot by
+#   inspecting the fitted model returned from the cross-validation.
 
 # %%
 from sklearn.linear_model import LinearRegression
 
 linear_regression = LinearRegression()
-linear_regression.fit(X_train, y_train)
 
 # %%
-from sklearn.metrics import mean_absolute_error
+from sklearn.model_selection import cross_validate
 
-y_pred = linear_regression.predict(X_test)
+cv_results = cross_validate(linear_regression, X, y,
+                            scoring="neg_mean_absolute_error",
+                            return_estimator=True,
+                            cv=10,
+                            n_jobs=-1)
+
+# %%
 print(f"Mean absolute error on testing set: "
-      f"{mean_absolute_error(y_test, y_pred):.3f} k$")
+      f"{-cv_results['test_score'].mean():.3f} k$ +/- "
+      f"{cv_results['test_score'].std():.3f}")
 
 # %%
 import pandas as pd
@@ -54,8 +55,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 sns.set_context("talk")
 
-weights = pd.Series(linear_regression.coef_, index=X.columns)
-weights.plot(kind="barh")
+weights = pd.DataFrame(
+    [est.coef_ for est in cv_results["estimator"]], columns=X.columns)
+weights.plot.box(vert=False)
 _ = plt.title("Value of linear regression coefficients")
-
-# %%

--- a/python_scripts/linear_regression_non_linear_link.py
+++ b/python_scripts/linear_regression_non_linear_link.py
@@ -122,7 +122,7 @@ mse = mean_squared_error(y, y_pred)
 
 ax = sns.scatterplot(data=data, x="x", y="y")
 ax.plot(x[sorted_idx], y_pred[sorted_idx],
-        linewidth=4, color="tab:orange")
+        color="tab:orange")
 _ = ax.set_title(f"Mean squared error = {mse:.2f}")
 
 # %% [markdown]

--- a/python_scripts/parameter_tuning_manual.py
+++ b/python_scripts/parameter_tuning_manual.py
@@ -31,15 +31,6 @@ data = df[numerical_columns]
 data.head()
 
 # %% [markdown]
-# We now divide the dataset into two subsets.
-
-# %%
-from sklearn.model_selection import train_test_split
-
-data_train, data_test, target_train, target_test = train_test_split(
-    data, target, random_state=42)
-
-# %% [markdown]
 # Let's create a simple predictive model made of a scaler followed by a
 # logistic regression classifier.
 #
@@ -56,10 +47,18 @@ model = Pipeline(steps=[
     ("preprocessor", StandardScaler()),
     ("classifier", LogisticRegression())
 ])
-model.fit(data_train, target_train)
+
+# %% [markdown]
+# We can evaluate the statistical performance of the model via
+# cross-validation.
 
 # %%
-model.score(data_test, target_test)
+from sklearn.model_selection import cross_validate
+
+cv_results = cross_validate(model, data, target)
+scores = cv_results["test_score"]
+print(f"Accuracy score via cross-validation:\n"
+      f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
 # We created a model with the default `C` value that is equal to 1. We saw in
@@ -74,9 +73,10 @@ model.score(data_test, target_test)
 
 # %%
 model.set_params(classifier__C=1e-3)
-model.fit(data_train, target_train)
-print(f"The test accuracy score of the model is: "
-      f"{model.score(data_test, target_test):.3f}")
+cv_results = cross_validate(model, data, target)
+scores = cv_results["test_score"]
+print(f"Accuracy score via cross-validation:\n"
+      f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
 # When the model of interest is a `Pipeline`, the parameter names are of the
@@ -107,9 +107,10 @@ model.get_params()['classifier__C']
 # %%
 for C in [1e-3, 1e-2, 1e-1, 1, 10]:
     model.set_params(classifier__C=C)
-    model.fit(data_train, target_train)
-    print(f"The test accuracy score with C={C} is: "
-          f"{model.score(data_test, target_test):.3f}")
+    cv_results = cross_validate(model, data, target)
+    scores = cv_results["test_score"]
+    print(f"Accuracy score via cross-validation with C={C}:\n"
+          f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
 # We can see that as long as C is high enough, the model seems to perform


### PR DESCRIPTION
closes #194

Use cross-validation whenever possible instead of a single train-test split.
When this is not possible (for the sake of clarity or computation time), I added a disclaimer.
We should make an additional pass on the example to see if we should sometimes add an additional disclaimer as well.