### PR TITLE
use handle_unknown in OrdinalEncoder and OneHotEncoder

### DIFF
--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -287,14 +287,16 @@ data["native-country"].value_counts()
 #
 # * list all the possible categories and provide it to the encoder via the
 #   keyword argument `categories`;
-# * set the parameter `handle_unknown="ignore"`.
+# * use the parameter `handle_unknown`.
 #
-# Here, we will use the former strategy because we are also going to use it for
-# the ordinal encoder later on.
+# Here, we will use the latter solution for simplicity.
 
-# %%
-categories = [data_categorical[column].unique()
-              for column in data_categorical]
+# %% [markdown]
+# ```{tip}
+# Be aware the the `OrdinalEncoder` exposes as well a parameter
+# `handle_unknown`. It can be set to `use_encoded_value` and by setting
+# `unknown_value` to handle rare categories.
+# ```
 
 # %% [markdown]
 # We can now create our machine learning pipeline.
@@ -304,8 +306,8 @@ from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import LogisticRegression
 
 model = make_pipeline(
-    OneHotEncoder(categories=categories, drop="if_binary"),
-    LogisticRegression(max_iter=500))
+    OneHotEncoder(handle_unknown="ignore"), LogisticRegression(max_iter=500)
+)
 
 # %% {markdown}
 # ```{note}

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -65,14 +65,6 @@ numerical_columns = numerical_columns_selector(data)
 categorical_columns = categorical_columns_selector(data)
 
 # %% [markdown]
-# Besides, we will list the categories for each categorical column beforehand
-# to avoid issues with rare categories when evaluating the model.
-
-# %%
-categories = [data[column].unique()
-              for column in categorical_columns]
-
-# %% [markdown]
 # ## Dispatch columns to a specific processor
 #
 # In the previous sections, we saw that we need to treat data differently
@@ -86,8 +78,8 @@ categories = [data[column].unique()
 # We first define the columns depending on their data type:
 #
 # * **one-hot encoding** will be applied to categorical columns. Besides, we
-#   will use the option `drop="if_binary"` to drop one of the column since the
-#   information will be correlated;
+#   use `handle_unknown="ignore"` to solve the potential issues due to rare
+#   categories.
 # * **numerical scaling** numerical features which will be standardized.
 #
 # Now, we create our `ColumnTransfomer` by specifying three values:
@@ -98,8 +90,7 @@ categories = [data[column].unique()
 # %%
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
-categorical_preprocessor = OneHotEncoder(categories=categories,
-                                         drop="if_binary")
+categorical_preprocessor = OneHotEncoder(handle_unknown="ignore")
 numerical_preprocessor = StandardScaler()
 
 # %% [markdown]
@@ -228,7 +219,8 @@ from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.preprocessing import OrdinalEncoder
 
-categorical_preprocessor = OrdinalEncoder(categories=categories)
+categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",
+                                          unknown_value=-1)
 
 preprocessor = ColumnTransformer([
     ('categorical', categorical_preprocessor, categorical_columns)],

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -37,7 +37,7 @@ adult_census = pd.read_csv("../datasets/adult-census.csv")
 # %%
 target_name = "class"
 target = adult_census[target_name]
-data = adult_census.drop(columns=[target_name, "fnlwgt"])
+data = adult_census.drop(columns=[target_name, "fnlwgt", "education-num"])
 
 # %% [markdown]
 # We can select the categorical based on the `object` dtype.

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -26,14 +26,8 @@
 # `OneHotEncoder` or to some other baseline score.
 #
 # Because `OrdinalEncoder` can raise errors if it sees an unknown category at
-# prediction time, we need to pre-compute the list of all possible categories
-# ahead of time:
-#
-# ```python
-# categories = [data[column].unique()
-#               for column in data[categorical_columns]]
-# OrdinalEncoder(categories=categories)
-# ```
+# prediction time, you can set the `handle_unknown` and `unknown_value`
+# parameters.
 
 # %%
 import pandas as pd

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -24,10 +24,6 @@
 # - The second question is to evaluate whether it is empirically better (both
 #   from a computational and a statistical perspective) to use integer coded or
 #   one-hot encoded categories.
-#
-# Hint: `HistGradientBoostingClassifier` does not yet support sparse input
-# data. You might want to use `OneHotEncoder(categories=categories,
-# sparse=False)` to force the use a dense representation as a workaround.
 
 # %%
 import pandas as pd
@@ -52,9 +48,6 @@ categorical_columns_selector = selector(dtype_include=object)
 numerical_columns = numerical_columns_selector(data)
 categorical_columns = categorical_columns_selector(data)
 
-categories = [
-    data[column].unique() for column in data[categorical_columns]]
-
 # %% [markdown]
 # ## Reference pipeline (no numerical scaling and integer-coded categories)
 #
@@ -70,7 +63,8 @@ from sklearn.preprocessing import OrdinalEncoder
 from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 
-categorical_preprocessor = OrdinalEncoder(categories=categories)
+categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",
+                                          unknown_value=-1)
 preprocessor = ColumnTransformer([
     ('categorical', categorical_preprocessor, categorical_columns)],
     remainder="passthrough")
@@ -100,12 +94,9 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 #
 # Let's see if we can get an even better accuracy with `OneHotEncoder`.
 #
-# Reminder: in order to avoid creating fully correlated features it is
-# preferable to use a `OneHotEncoder` using the option `drop="if_binary"`.
-#
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(categories=categories, sparse=False)` to force the use a
+# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a
 # dense representation as a workaround.
 
 # %%

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -26,14 +26,8 @@
 # `OneHotEncoder` or to some other baseline score.
 #
 # Because `OrdinalEncoder` can raise errors if it sees an unknown category at
-# prediction time, we need to pre-compute the list of all possible categories
-# ahead of time:
-#
-# ```python
-# categories = [data[column].unique()
-#               for column in data[categorical_columns]]
-# OrdinalEncoder(categories=categories)
-# ```
+# prediction time, you can set the `handle_unknown` and `unknown_value`
+# parameters.
 
 # %%
 import pandas as pd
@@ -56,16 +50,6 @@ categorical_columns = categorical_columns_selector(data)
 data_categorical = data[categorical_columns]
 
 # %% [markdown]
-# As we saw in the lecture notebook, one of the column has rare categories.
-# Thus, we can make sure to not run into trouble in the cross-validation by
-# specifying the known categories in advance.
-
-# %%
-categories = [
-    data[column].unique() for column in data[categorical_columns]]
-categories
-
-# %% [markdown]
 # Now, let's make our predictive pipeline by encoding categories with an
 # ordinal encoder before to feed a logistic regression.
 
@@ -76,7 +60,7 @@ from sklearn.preprocessing import OrdinalEncoder
 from sklearn.linear_model import LogisticRegression
 
 model = make_pipeline(
-    OrdinalEncoder(categories=categories),
+    OrdinalEncoder(handle_unknown="use_encoded_value", unknown_value=-1),
     LogisticRegression(max_iter=500))
 cv_results = cross_validate(model, data_categorical, target)
 scores = cv_results["test_score"]
@@ -111,7 +95,7 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 from sklearn.preprocessing import OneHotEncoder
 
 model = make_pipeline(
-    OneHotEncoder(categories=categories, drop="if_binary"),
+    OneHotEncoder(handle_unknown="ignore"),
     LogisticRegression(max_iter=500))
 cv_results = cross_validate(model, data_categorical, target)
 scores = cv_results["test_score"]

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -112,14 +112,11 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # `HistGradientBoostingClassifier` models, it does not seem to be the case as
 # the cross-validation of the reference pipeline with `OrdinalEncoder` is good.
 #
-# Let's see if we can get an even better accuracy with `OneHotEncoder`:
-#
-# Reminder: in order to avoid creating fully correlated features it is
-# preferable to use a `OneHotEncoder` with the option `drop="if_binary"`.
+# Let's see if we can get an even better accuracy with `OneHotEncoder`.
 #
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(categories=categories, sparse=False)` to force the use a
+# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use a
 # dense representation as a workaround.
 
 # %%

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -48,9 +48,6 @@ categorical_columns_selector = selector(dtype_include=object)
 numerical_columns = numerical_columns_selector(data)
 categorical_columns = categorical_columns_selector(data)
 
-categories = [
-    data[column].unique() for column in data[categorical_columns]]
-
 # %% [markdown]
 # ## Reference pipeline (no numerical scaling and integer-coded categories)
 #
@@ -66,7 +63,8 @@ from sklearn.preprocessing import OrdinalEncoder
 from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 
-categorical_preprocessor = OrdinalEncoder(categories=categories)
+categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",
+                                          unknown_value=-1)
 preprocessor = ColumnTransformer([
     ('categorical', categorical_preprocessor, categorical_columns)],
     remainder="passthrough")
@@ -86,7 +84,8 @@ from sklearn.preprocessing import StandardScaler
 
 preprocessor = ColumnTransformer([
     ('numerical', StandardScaler(), numerical_columns),
-    ('categorical', OrdinalEncoder(categories=categories),
+    ('categorical', OrdinalEncoder(handle_unknown="use_encoded_value",
+                                   unknown_value=-1),
      categorical_columns)])
 
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
@@ -127,8 +126,7 @@ print(f"The accuracy is: {scores.mean():.3f} +- {scores.std():.3f}")
 # %%time
 from sklearn.preprocessing import OneHotEncoder
 
-categorical_preprocessor = OneHotEncoder(
-    categories=categories, drop="if_binary", sparse=False)
+categorical_preprocessor = OneHotEncoder(handle_unknown="ignore", sparse=False)
 preprocessor = ColumnTransformer([
     ('one-hot-encoder', categorical_preprocessor, categorical_columns)],
     remainder="passthrough")

--- a/python_scripts/parameter_tuning_automated.py
+++ b/python_scripts/parameter_tuning_automated.py
@@ -72,10 +72,8 @@ categorical_columns = categorical_columns_selector(data)
 # %%
 from sklearn.preprocessing import OrdinalEncoder
 
-categories = [
-    data[column].unique() for column in data[categorical_columns]]
-
-categorical_preprocessor = OrdinalEncoder(categories=categories)
+categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",
+                                          unknown_value=-1)
 
 # %% [markdown]
 # We now use a column transformer with code to select the categorical columns
@@ -90,7 +88,7 @@ preprocessor = ColumnTransformer([
 
 # %% [markdown]
 # Finally, we use a tree-based classifier (i.e. histogram gradient-boosting) to
-# predict whether or not a person earns more than 50,000 dollars a year.
+# predict whether or not a person earns more than 50 k$ a year.
 
 # %%
 # %%time

--- a/python_scripts/parameter_tuning_ex_02.py
+++ b/python_scripts/parameter_tuning_ex_02.py
@@ -32,25 +32,21 @@ adult_census = pd.read_csv("../datasets/adult-census.csv")
 
 target_name = "class"
 target = adult_census[target_name]
-data = adult_census.drop(columns=[target_name, "fnlwgt"])
+data = adult_census.drop(columns=[target_name, "fnlwgt", "education-num"])
 
-df_train, df_test, target_train, target_test = train_test_split(
+data_train, data_test, target_train, target_test = train_test_split(
     data, target, train_size=0.2, random_state=42)
 
+# %%
 from sklearn.compose import ColumnTransformer
+from sklearn.compose import make_column_selector as selector
 from sklearn.preprocessing import OrdinalEncoder
 
-categorical_columns = [
-    'workclass', 'education', 'marital-status', 'occupation',
-    'relationship', 'race', 'native-country', 'sex']
-
-categories = [data[column].unique()
-              for column in data[categorical_columns]]
-
-categorical_preprocessor = OrdinalEncoder(categories=categories)
-
+categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",
+                                          unknown_value=-1)
 preprocessor = ColumnTransformer(
-    [('cat-preprocessor', categorical_preprocessor, categorical_columns)],
+    [('cat-preprocessor', categorical_preprocessor,
+      selector(dtype_include=object))],
     remainder='passthrough', sparse_threshold=0)
 
 # This line is currently required to import HistGradientBoostingClassifier

--- a/python_scripts/parameter_tuning_ex_03.py
+++ b/python_scripts/parameter_tuning_ex_03.py
@@ -30,7 +30,7 @@ adult_census = pd.read_csv("../datasets/adult-census.csv")
 
 target_name = "class"
 target = adult_census[target_name]
-data = adult_census.drop(columns=[target_name, "fnlwgt"])
+data = adult_census.drop(columns=[target_name, "fnlwgt", "education-num"])
 
 from sklearn.model_selection import train_test_split
 

--- a/python_scripts/parameter_tuning_sol_02.py
+++ b/python_scripts/parameter_tuning_sol_02.py
@@ -32,7 +32,7 @@ adult_census = pd.read_csv("../datasets/adult-census.csv")
 
 target_name = "class"
 target = adult_census[target_name]
-data = adult_census.drop(columns=[target_name, "fnlwgt"])
+data = adult_census.drop(columns=[target_name, "fnlwgt", "education-num"])
 
 data_train, data_test, target_train, target_test = train_test_split(
     data, target, train_size=0.2, random_state=42)

--- a/python_scripts/parameter_tuning_sol_02.py
+++ b/python_scripts/parameter_tuning_sol_02.py
@@ -34,23 +34,19 @@ target_name = "class"
 target = adult_census[target_name]
 data = adult_census.drop(columns=[target_name, "fnlwgt"])
 
-df_train, df_test, target_train, target_test = train_test_split(
+data_train, data_test, target_train, target_test = train_test_split(
     data, target, train_size=0.2, random_state=42)
 
+# %%
 from sklearn.compose import ColumnTransformer
+from sklearn.compose import make_column_selector as selector
 from sklearn.preprocessing import OrdinalEncoder
 
-categorical_columns = [
-    'workclass', 'education', 'marital-status', 'occupation',
-    'relationship', 'race', 'native-country', 'sex']
-
-categories = [data[column].unique()
-              for column in data[categorical_columns]]
-
-categorical_preprocessor = OrdinalEncoder(categories=categories)
-
+categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",
+                                          unknown_value=-1)
 preprocessor = ColumnTransformer(
-    [('cat-preprocessor', categorical_preprocessor, categorical_columns)],
+    [('cat-preprocessor', categorical_preprocessor,
+      selector(dtype_include=object))],
     remainder='passthrough', sparse_threshold=0)
 
 # This line is currently required to import HistGradientBoostingClassifier
@@ -93,7 +89,7 @@ for lr in learning_rate:
             classifier__learning_rate=lr,
             classifier__max_leaf_nodes=mln
         )
-        scores = cross_val_score(model, df_train, target_train, cv=2)
+        scores = cross_val_score(model, data_train, target_train, cv=2)
         mean_score = scores.mean()
         print(f"score: {mean_score:.3f}")
         if mean_score > best_score:

--- a/python_scripts/parameter_tuning_sol_03.py
+++ b/python_scripts/parameter_tuning_sol_03.py
@@ -30,7 +30,7 @@ adult_census = pd.read_csv("../datasets/adult-census.csv")
 
 target_name = "class"
 target = adult_census[target_name]
-data = adult_census.drop(columns=[target_name, "fnlwgt"])
+data = adult_census.drop(columns=[target_name, "fnlwgt", "education-num"])
 
 from sklearn.model_selection import train_test_split
 
@@ -52,9 +52,6 @@ from sklearn.compose import make_column_selector as selector
 categorical_columns_selector = selector(dtype_include=object)
 categorical_columns = categorical_columns_selector(data)
 
-categories = [data[column].unique()
-              for column in data[categorical_columns]]
-
 numerical_columns_selector = selector(dtype_exclude=object)
 numerical_columns = numerical_columns_selector(data)
 
@@ -62,15 +59,14 @@ numerical_columns = numerical_columns_selector(data)
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import StandardScaler
 
-categorical_processor = OneHotEncoder(categories=categories,
-                                      drop="if_binary")
+categorical_processor = OneHotEncoder(handle_unknown="ignore")
 numerical_processor = StandardScaler()
 
 # %% [markdown]
 # Subsequently, create a `ColumnTransformer` to redirect the specific columns
 # a preprocessing pipeline.
-# %%
 
+# %%
 from sklearn.compose import ColumnTransformer
 
 preprocessor = ColumnTransformer(
@@ -80,8 +76,8 @@ preprocessor = ColumnTransformer(
 
 # %% [markdown]
 # Finally, concatenate the preprocessing pipeline with a logistic regression.
-# %%
 
+# %%
 from sklearn.pipeline import make_pipeline
 from sklearn.linear_model import LogisticRegression
 


### PR DESCRIPTION
closes #74 

Use `handle_unknown` to show how to deal with rare categories.