### PR TITLE
Use loguniform rather than reciprocal.

### DIFF
--- a/python_scripts/parameter_tuning_ex_03.py
+++ b/python_scripts/parameter_tuning_ex_03.py
@@ -72,8 +72,8 @@ from sklearn.linear_model import LogisticRegression
 #
 # Use a `RandomizedSearchCV` to find the best set of hyperparameters by tuning
 # the following parameters for the `LogisticRegression` model:
-# - `C` with values ranging from 0.001 to 10. You can use a reciprocal
-#   distribution (i.e. `scipy.stats.reciprocal`);
+# - `C` with values ranging from 0.001 to 10. You can use a log-uniform
+#   distribution (i.e. `scipy.stats.loguniform`);
 # - `solver` with possible values being `"liblinear"` and `"lbfgs"`;
 # - `penalty` with possible values being `"l2"` and `"l1"`;
 #

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -108,10 +108,9 @@ model
 # The `RandomizedSearchCV` class allows for such stochastic search. It is
 # used similarly to the `GridSearchCV` but the sampling distributions
 # need to be specified instead of the parameter values. For instance, we
-# will draw candidates using a log-uniform distribution also called
-# reciprocal distribution, because the parameters we are interested in
-# take positive values with a natural log scaling (.1 is as close to 1 as
-# 10 is).
+# will draw candidates using a log-uniform distribution because the parameters
+# we are interested in take positive values with a natural log scaling (.1 is
+# as close to 1 as 10 is).
 #
 # ```{note}
 # Random search (with `RandomizedSearchCV`) is typically beneficial compared
@@ -129,19 +128,19 @@ model
 #   histograms.
 #
 # ```{note}
-# The `reciprocal` function from SciPy returns a floating number. Since we
+# The `loguniform` function from SciPy returns a floating number. Since we
 # want to us this distribution to create integer, we will create a class that
 # will cast the floating number into an integer.
 # ```
 
 # %%
-from scipy.stats import reciprocal
+from scipy.stats import loguniform
 
 
-class reciprocal_int:
+class loguniform_int:
     """Integer valued version of the log-uniform distribution"""
     def __init__(self, a, b):
-        self._distribution = reciprocal(a, b)
+        self._distribution = loguniform(a, b)
 
     def rvs(self, *args, **kwargs):
         """Random variable sample"""
@@ -155,11 +154,11 @@ class reciprocal_int:
 from sklearn.model_selection import RandomizedSearchCV
 
 param_distributions = {
-    'classifier__l2_regularization': reciprocal(1e-6, 1e3),
-    'classifier__learning_rate': reciprocal(0.001, 10),
-    'classifier__max_leaf_nodes': reciprocal_int(2, 256),
-    'classifier__min_samples_leaf': reciprocal_int(1, 100),
-    'classifier__max_bins': reciprocal_int(2, 255)}
+    'classifier__l2_regularization': loguniform(1e-6, 1e3),
+    'classifier__learning_rate': loguniform(0.001, 10),
+    'classifier__max_leaf_nodes': loguniform_int(2, 256),
+    'classifier__min_samples_leaf': loguniform_int(1, 100),
+    'classifier__max_bins': loguniform_int(2, 255)}
 
 model_random_search = RandomizedSearchCV(
     model, param_distributions=param_distributions, n_iter=10,

--- a/python_scripts/parameter_tuning_sol_03.py
+++ b/python_scripts/parameter_tuning_sol_03.py
@@ -86,8 +86,8 @@ model = make_pipeline(preprocessor, LogisticRegression())
 # %% [markdown]
 # Use a `RandomizedSearchCV` to find the best set of hyperparameters by tuning
 # the following parameters for the `LogisticRegression` model:
-# - `C` with values ranging from 0.001 to 10. You can use a reciprocal
-#   distribution (i.e. `scipy.stats.reciprocal`);
+# - `C` with values ranging from 0.001 to 10. You can use a log-uniform
+#   distribution (i.e. `scipy.stats.loguniform`);
 # - `solver` with possible values being `"liblinear"` and `"lbfgs"`;
 # - `penalty` with possible values being `"l2"` and `"l1"`;
 #
@@ -105,10 +105,10 @@ model = make_pipeline(preprocessor, LogisticRegression())
 
 # %%
 from sklearn.model_selection import RandomizedSearchCV
-from scipy.stats import reciprocal
+from scipy.stats import loguniform
 
 param_distributions = {
-    "logisticregression__C": reciprocal(0.001, 10),
+    "logisticregression__C": loguniform(0.001, 10),
     "logisticregression__solver": ["liblinear", "lbfgs"],
     "logisticregression__penalty": ["l2", "l1"],
     "columntransformer__cat-preprocessor__drop": [None, "first"]


### PR DESCRIPTION
loguniform has been added in scipy 1.14 (released December 2019)

log-uniform is easier to grasp (and remember) than reciprocal also this avoids mentioning both names.