### PR TITLE
Reworked bootstrapping notebook

### DIFF
--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -71,7 +71,7 @@ _ = plt.title("Predictions by a single decision tree")
 #
 # ## Bootstrap resampling
 #
-# A bootstrap sample corresponds to a resampling, with replacement, of the
+# A bootstrap sample corresponds to a resampling with replacement, of the
 # original dataset, a sample that is the same size as the original dataset.
 # Thus, the bootstrap sample will contain some data points several times while
 # some of the original data points will not be present.
@@ -221,7 +221,7 @@ _ = plt.title("Predictions of bagged trees")
 # an estimator that wraps another estimator: it takes a base model that is
 # cloned several times and trained independently on each bootstrap sample.
 #
-# The following shows how to build a bagging ensemble of decision trees. We set
+# The following code snippet shows how to build a bagging ensemble of decision trees. We set
 # `n_estimtators=100` instead of 3 in our manual implementation above to get
 # a stronger smoothing effect.
 
@@ -240,7 +240,8 @@ _ = bagged_trees.fit(data_train, target_train)
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, bagged_trees.predict(data_test))
+target_predicted = bagged_trees.predict(data_test)
+plt.plot(data_test, target_predicted)
 _ = plt.title("Predictions from a bagging classifier")
 
 # %% [markdown]
@@ -248,7 +249,7 @@ _ = plt.title("Predictions from a bagging classifier")
 # Because we use 100 trees in the ensemble, the average prediction is indeed
 # slightly smoother but very similar to our previous average plot.
 #
-# It is possible to access the internel models of the ensemble in stored as a
+# It is possible to access the internal models of the ensemble stored as a
 # Python list in the `bagged_trees.estimators_` attribute after fitting.
 #
 # Let us compare the based model predictions with their average:
@@ -256,13 +257,15 @@ _ = plt.title("Predictions from a bagging classifier")
 # %%
 for tree_idx, tree in enumerate(bagged_trees.estimators_):
     label = "Predictions of individual trees" if tree_idx == 0 else None
-    plt.plot(data_test, tree.predict(data_test), linestyle="--", alpha=0.1,
+    target_tree_predicted = tree.predict(data_test)
+    plt.plot(data_test, target_tree_predicted, linestyle="--", alpha=0.1,
              color="tab:blue", label=label)
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
-plt.plot(data_test, bagged_trees.predict(data_test),
+target_bagged_trees_predicted = bagged_trees.predict(data_test)
+plt.plot(data_test, target_bagged_trees_predicted,
          color="tab:orange", label="Predictions of ensemble")
 _ = plt.legend()
 

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -1,12 +1,13 @@
 # %% [markdown]
 # # Bagging
 #
-# In this notebook, we will present the first ensemble using bootstrap samples
-# called bagging.
+# This notebook introduces a very natural strategy to build ensembles of
+# machine learning models named "bagging".
 #
-# Bagging stands for Bootstrap AGGregatING. It uses bootstrap (random sampling
-# with replacement) to learn several models. At predict time, the predictions
-# of each learner are aggregated to give the final predictions.
+# "Bagging" stands for Bootstrap AGGregatING. It uses bootstrap resampling
+# (random sampling with replacement) to learn several models on random
+# variations of the training set. At predict time, the predictions of each
+# learner are aggregated to give the final predictions.
 #
 # First, we will generate a simple synthetic dataset to get insights regarding
 # bootstraping.
@@ -16,17 +17,17 @@ import pandas as pd
 import numpy as np
 
 # create a random number generator that will be used to set the randomness
-rng = np.random.RandomState(0)
+rng = np.random.RandomState(1)
 
 
-def generate_data(n_samples=50):
+def generate_data(n_samples=30):
     """Generate synthetic dataset. Returns `data_train`, `data_test`,
     `target_train`."""
-    x_max, x_min = 1.4, -1.4
-    len_x = x_max - x_min
-    x = rng.rand(n_samples) * len_x - len_x / 2
-    noise = rng.randn(n_samples) * 0.3
-    y = x ** 3 - 0.5 * x ** 2 + noise
+    x_min, x_max = -3, 3
+    x = rng.uniform(x_min, x_max, size=n_samples)
+    noise = 4.0 * rng.randn(n_samples)
+    y = x ** 3 - 0.5 * (x + 1) ** 2 + noise
+    y /= y.std()
 
     data_train = pd.DataFrame(x, columns=["Feature"])
     data_test = pd.DataFrame(
@@ -40,14 +41,16 @@ def generate_data(n_samples=50):
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-data_train, data_test, target_train = generate_data(n_samples=50)
+data_train, data_test, target_train = generate_data(n_samples=30)
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 _ = plt.title("Synthetic regression dataset")
 
 # %% [markdown]
-# The link between our feature and the target to predict is non-linear.
-# However, a decision tree is capable of fitting such data.
+#
+# The relationship between our feature and the target to predict is non-linear.
+# However, a decision tree is capable of approximating such a non-linear
+# dependency:
 
 # %%
 from sklearn.tree import DecisionTreeRegressor
@@ -66,7 +69,7 @@ _ = plt.title("Predictions by a single decision tree")
 # %% [markdown]
 # Let's see how we can use bootstraping to learn several trees.
 #
-# ## Bootstrap sample
+# ## Bootstrap resampling
 #
 # A bootstrap sample corresponds to a resampling, with replacement, of the
 # original dataset, a sample that is the same size as the original dataset.
@@ -74,63 +77,54 @@ _ = plt.title("Predictions by a single decision tree")
 # some of the original data points will not be present.
 #
 # We will create a function that given `data` and `target` will return a
-# bootstrap sample `data_bootstrap` and `target_bootstrap`.
+# resampled variation `data_bootstrap` and `target_bootstrap`.
 
 
 # %%
 def bootstrap_sample(data, target):
-    # indices corresponding to a sampling with replacement of the same sample
+    # Indices corresponding to a sampling with replacement of the same sample
     # size than the original data
     bootstrap_indices = rng.choice(
         np.arange(target.shape[0]), size=target.shape[0], replace=True,
     )
-    data_bootstrap_sample = data.iloc[bootstrap_indices]
-    target_bootstrap_sample = target.iloc[bootstrap_indices]
-    return data_bootstrap_sample, target_bootstrap_sample
+    # In pandas, we need to use `.iloc` to extract rows using an integer
+    # position index:
+    data_bootstrap = data.iloc[bootstrap_indices]
+    target_bootstrap = target.iloc[bootstrap_indices]
+    return data_bootstrap, target_bootstrap
 
 
 # %% [markdown]
+#
 # We will generate 3 bootstrap samples and qualitatively check the difference
 # with the original dataset.
 
 # %%
-bootstraps_illustration = pd.DataFrame()
-bootstraps_illustration["Original"] = data_train["Feature"]
-
-n_bootstrap = 3
-for bootstrap_idx in range(n_bootstrap):
+n_bootstraps = 3
+for bootstrap_idx in range(n_bootstraps):
     # draw a bootstrap from the original data
-    bootstrap_data, target_data = bootstrap_sample(data_train, target_train)
-    # store only the bootstrap sample
-    bootstraps_illustration[f"Boostrap sample #{bootstrap_idx + 1}"] = \
-        bootstrap_data["Feature"].to_numpy()
+    data_bootstrap, target_booststrap = bootstrap_sample(
+        data_train, target_train,
+    )
+    plt.figure()
+    plt.scatter(data_bootstrap["Feature"], target_booststrap,
+                color="tab:blue", facecolors="none",
+                alpha=0.5, label="Resampled data", s=180, linewidth=5)
+    plt.scatter(data_train["Feature"], target_train,
+                color="black", s=60,
+                alpha=1, label="Original data")
+    plt.title(f"Resampled data #{bootstrap_idx}")
+    plt.legend()
 
 # %% [markdown]
-# In the cell above, we generated three bootstrap samples and we stored only
-# the feature values. In this manner, we will plot the features value from each
-# set and check the how different they are.
 #
-# ```{note}
-# In the next cell, we transform the dataframe from wide to long format. The
-# column name become a by row information. `pd.melt` is in charge of doing this
-# transformation. We make this transformation because we will use the seaborn
-# function `sns.swarmplot` that expect long format dataframe.
-# ```
-
-# %%
-bootstraps_illustration = bootstraps_illustration.melt(
-    var_name="Type of data", value_name="Feature")
-
-# %%
-sns.swarmplot(x=bootstraps_illustration["Feature"],
-              y=bootstraps_illustration["Type of data"])
-_ = plt.title("Feature values for the different sets")
-
-# %% [markdown]
-# We observe that the 3 generated bootstrap samples are all different from the
-# original dataset. The sampling with replacement is the cause of this
-# fluctuation. To confirm this intuition, we can check the number of unique
-# samples in the bootstrap samples.
+# Observe that the 3 variations all share common points with the original
+# dataset. Some of the points are randomly resampled several times and appear
+# as darker blue circles.
+#
+# The 3 generated bootstrap samples are all different from the original dataset
+# and from each other. To confirm this intuition, we can check the number of
+# unique samples in the bootstrap samples.
 
 # %%
 data_train_huge, data_test_huge, target_train_huge = generate_data(
@@ -146,33 +140,36 @@ print(
 )
 
 # %% [markdown]
+#
 # On average, ~63.2% of the original data points of the original dataset will
-# be present in the bootstrap sample. The other ~36.8% are just repeated
+# be present in a given bootstrap sample. The other ~36.8% are repeated
 # samples.
 #
-# So, we are able to generate many datasets, all slightly different. Now, we
-# can fit a decision tree for each of these datasets and they all
-# shall be slightly different as well.
+# We are able to generate many datasets, all slightly different.
+#
+# Now, we can fit a decision tree for each of these datasets and they all shall
+# be slightly different as well.
+
 
 # %%
-forest = []
-for bootstrap_idx in range(n_bootstrap):
+bag_of_trees = []
+for bootstrap_idx in range(n_bootstraps):
     tree = DecisionTreeRegressor(max_depth=3, random_state=0)
 
     data_bootstrap_sample, target_bootstrap_sample = bootstrap_sample(
         data_train, target_train)
     tree.fit(data_bootstrap_sample, target_bootstrap_sample)
-    forest.append(tree)
+    bag_of_trees.append(tree)
 
 # %% [markdown]
-# Now that we created a forest with many different trees, we can use each of
-# the tree to predict on the testing data. They shall give slightly different
-# results.
+#
+# Now that we created a bag of different trees, we can use each of the tree to
+# predict on the testing data. They shall give slightly different predictions.
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-for tree_idx, tree in enumerate(forest):
+for tree_idx, tree in enumerate(bag_of_trees):
     target_predicted = tree.predict(data_test)
     plt.plot(data_test, target_predicted, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
@@ -184,72 +181,156 @@ _ = plt.title("Predictions of trees trained on different bootstraps")
 # ## Aggregating
 #
 # Once our trees are fitted and we are able to get predictions for each of
-# them, we need to combine them. In regression, the most straightforward
-# approach is to average the different predictions from all learners. We can
-# plot the averaged predictions from the previous example.
+# them. In regression, the most straightforward way to combine those
+# predictions is just to average them: for a given test data point, we feed the
+# input feature values to each of the `n` trained models in the ensemble and as
+# a resutl compute `n` predicted values for the target varible. The final
+# prediction of the ensemble for the test data point is the average of those
+# `n` values.
+#
+# We can plot the averaged predictions from the previous example.
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
-target_predicted_forest = []
-for tree_idx, tree in enumerate(forest):
+bag_predictions = []
+for tree_idx, tree in enumerate(bag_of_trees):
     target_predicted = tree.predict(data_test)
     plt.plot(data_test, target_predicted, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
-    target_predicted_forest.append(target_predicted)
+    bag_predictions.append(target_predicted)
 
-target_predicted_forest = np.mean(target_predicted_forest, axis=0)
-plt.plot(data_test, target_predicted_forest, label="Averaged predictions",
+bag_predictions = np.mean(bag_predictions, axis=0)
+plt.plot(data_test, bag_predictions, label="Averaged predictions",
          linestyle="-")
 plt.legend()
-plt.title("Predictions of individual and combined tree")
+_ = plt.title("Predictions of bagged trees")
 
 # %% [markdown]
+#
 # The unbroken red line shows the averaged predictions, which would be the
-# final preditions given by our 'bag' of decision tree regressors.
+# final preditions given by our 'bag' of decision tree regressors. Note that
+# the predictions of the ensemble is more stable because of the averaging
+# operation. As a result, the bag of trees as a whole is less likely to overfit
+# than the individual trees.
 #
 # ## Bagging in scikit-learn
 #
-# Scikit-learn implements bagging estimators. It takes a base model that is the
-# model trained on each bootstrap sample.
+# Scikit-learn implements the bagging procedure as a "meta-estimator", that is
+# an estimator that wraps another estimator: it takes a base model that is
+# cloned several times and trained independently on each bootstrap sample.
+#
+# The following shows how to build a bagging ensemble of decision trees. We set
+# `n_estimtators=100` instead of 3 in our manual implementation above to get
+# a stronger smoothing effect.
 
 # %%
 from sklearn.ensemble import BaggingRegressor
 
-bagging = BaggingRegressor(base_estimator=DecisionTreeRegressor(),
-                           n_estimators=3)
-bagging.fit(data_train, target_train)
-target_predicted_forest = bagging.predict(data_test)
+bagged_trees = BaggingRegressor(
+    base_estimator=DecisionTreeRegressor(max_depth=3),
+    n_estimators=100,
+)
+_ = bagged_trees.fit(data_train, target_train)
 
+# %% [markdown]
+#
+# Let us visualize the predictions of the ensemble on the same test data:
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, target_predicted_forest, label="Bag of decision trees")
-plt.legend()
+plt.plot(data_test, bagged_trees.predict(data_test))
 _ = plt.title("Predictions from a bagging classifier")
 
 # %% [markdown]
-# While we used a decision tree as a base model, nothing prevent us of using
-# any other type of model. We will give an example that will use a linear
-# regression.
+#
+# Because we use 100 trees in the ensemble, the average prediction is indeed
+# slightly smoother but very similar to our previous average plot.
+#
+# It is possible to access the internel models of the ensemble in stored as a
+# Python list in the `bagged_trees.estimators_` attribute after fitting.
+#
+# Let us compare the based model predictions with their average:
 
 # %%
-from sklearn.linear_model import LinearRegression
+for tree_idx, tree in enumerate(bagged_trees.estimators_):
+    label = "Predictions of individual trees" if tree_idx == 0 else None
+    plt.plot(data_test, tree.predict(data_test), linestyle="--", alpha=0.1,
+             color="tab:blue", label=label)
 
-bagging = BaggingRegressor(base_estimator=LinearRegression(),
-                           n_estimators=3)
-bagging.fit(data_train, target_train)
-target_predicted_linear = bagging.predict(data_test)
-
-# %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, target_predicted_forest, label="Bag of decision trees")
-plt.plot(data_test, target_predicted_linear, label="Bag of linear regression")
-plt.legend()
-_ = plt.title("Bagging classifiers using \ndecision trees and linear models")
+
+plt.plot(data_test, bagged_trees.predict(data_test),
+         color="tab:orange", label="Predictions of ensemble")
+_ = plt.legend()
 
 # %% [markdown]
-# However, we see that using a bag of linear models is not helpful here because
-# we still obtain a linear model.
+#
+# We used a low value of the opacity parameter `alpha` to better appreciate the
+# overlap in the prediction functions of the individual trees.
+#
+# This visualization gives some insights on the uncertainty in the predictions
+# in different areas of the feature space.
+#
+# ## Bagging complex pipelines
+#
+# While we used a decision tree as a base model, nothing prevents us of using
+# any other type of model.
+#
+# As we know that the original data generating function is a noisy polynomial
+# transformation of the input variable, let us try to fit a bagged polynomial
+# regression pipeline on this dataset:
+
+# %%
+from sklearn.linear_model import Ridge
+from sklearn.preprocessing import PolynomialFeatures
+from sklearn.preprocessing import MinMaxScaler
+from sklearn.pipeline import make_pipeline
+
+
+polynomial_regressor = make_pipeline(
+    MinMaxScaler(),
+    PolynomialFeatures(degree=4),
+    Ridge(alpha=1e-10),
+)
+bagging = BaggingRegressor(
+    base_estimator=polynomial_regressor,
+    n_estimators=100,
+    random_state=0,
+)
+_ = bagging.fit(data_train, target_train)
+
+
+# %%
+for i, regr in enumerate(bagging.estimators_):
+    base_model_line = plt.plot(
+        data_test, regr.predict(data_test), linestyle="--", alpha=0.2,
+        label="Predictions of base models" if i == 0 else None,
+        color="tab:blue"
+    )
+
+sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
+                alpha=0.5)
+plt.plot(data_test, bagging.predict(data_test),
+         color="tab:orange", label="Predictions of ensemble")
+plt.ylim(target_train.min(), target_train.max())
+plt.legend()
+_ = plt.title("Bagged polynomial regression")
+
+# %% [markdown]
+#
+# The predictions of this bagged polynomial regression model looks
+# qualitatively better than the bagged trees. This is somewhat expected since
+# the base models better reflect our knowldge of the true data generating
+# process.
+#
+# Again the different shades induced by the overlapping blue lines let us
+# appreciate the uncertainty in the prediction of the bagged ensemble.
+#
+# To conclude this notebook, we note that the bootstrapping procedure is a
+# generic tool of statistics and is not limitted to build ensemble of machine
+# learning models. The interested reader can learn more on the [Wikpedia
+# article on
+# bootstrapping](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)).

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -300,6 +300,24 @@ polynomial_regressor = make_pipeline(
     PolynomialFeatures(degree=4),
     Ridge(alpha=1e-10),
 )
+
+# %% [markdown]
+#
+# This pipeline first scales the data to the 0-1 range with `MinMaxScaler`.
+# Then it extracts degree-4 polynomial features. The resulting features will
+# all stay in the 0-1 range by construction: if `x` lies in the 0-1 range then
+# `x ** n` also lies in the 0-1 range for any value of `n`.
+#
+# Then the pipeline feeds the resulting non-linear features to a regularized
+# linear regression model for the final prediction of the target variable.
+#
+# Note that we intentionally use a small value for the regularization parameter
+# `alpha` as we expect the bagging ensemble to work well with slightly overfit
+# base models.
+#
+# The ensemble itself is simply built by passing the resulting pipeline as the
+# `base_estimator` parameter of the `BaggingRegressor` class:
+
 bagging = BaggingRegressor(
     base_estimator=polynomial_regressor,
     n_estimators=100,

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -347,7 +347,7 @@ _ = plt.title("Bagged polynomial regression")
 #
 # The predictions of this bagged polynomial regression model looks
 # qualitatively better than the bagged trees. This is somewhat expected since
-# the base models better reflect our knowldge of the true data generating
+# the base model better reflects our knowldege of the true data generating
 # process.
 #
 # Again the different shades induced by the overlapping blue lines let us

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -337,7 +337,8 @@ for i, regressor in enumerate(bagging.estimators_):
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, bagging.predict(data_test),
+bagging_predictions = bagging.predict(data_test)
+plt.plot(data_test, bagging_predictions,
          color="tab:orange", label="Predictions of ensemble")
 plt.ylim(target_train.min(), target_train.max())
 plt.legend()

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -307,9 +307,10 @@ _ = bagging.fit(data_train, target_train)
 
 
 # %%
-for i, regr in enumerate(bagging.estimators_):
+for i, regressor in enumerate(bagging.estimators_):
+    target_regressor_predicted = regressor.predict(data_test)
     base_model_line = plt.plot(
-        data_test, regr.predict(data_test), linestyle="--", alpha=0.2,
+        data_test, target_regressor, linestyle="--", alpha=0.2,
         label="Predictions of base models" if i == 0 else None,
         color="tab:blue"
     )

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -170,8 +170,8 @@ for bootstrap_idx in range(n_bootstraps):
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 for tree_idx, tree in enumerate(bag_of_trees):
-    target_predicted = tree.predict(data_test)
-    plt.plot(data_test, target_predicted, linestyle="--", alpha=0.8,
+    tree_predictions = tree.predict(data_test)
+    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
 
 plt.legend()
@@ -196,10 +196,10 @@ sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
 
 bag_predictions = []
 for tree_idx, tree in enumerate(bag_of_trees):
-    target_predicted = tree.predict(data_test)
-    plt.plot(data_test, target_predicted, linestyle="--", alpha=0.8,
+    tree_predictions = tree.predict(data_test)
+    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
-    bag_predictions.append(target_predicted)
+    bag_predictions.append(tree_predictions)
 
 bag_predictions = np.mean(bag_predictions, axis=0)
 plt.plot(data_test, bag_predictions, label="Averaged predictions",
@@ -240,8 +240,10 @@ _ = bagged_trees.fit(data_train, target_train)
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-target_predicted = bagged_trees.predict(data_test)
-plt.plot(data_test, target_predicted)
+
+bagged_trees_predictions = bagged_trees.predict(data_test)
+plt.plot(data_test, bagged_trees_predictions)
+
 _ = plt.title("Predictions from a bagging classifier")
 
 # %% [markdown]
@@ -257,15 +259,15 @@ _ = plt.title("Predictions from a bagging classifier")
 # %%
 for tree_idx, tree in enumerate(bagged_trees.estimators_):
     label = "Predictions of individual trees" if tree_idx == 0 else None
-    target_tree_predicted = tree.predict(data_test)
-    plt.plot(data_test, target_tree_predicted, linestyle="--", alpha=0.1,
+    tree_predictions = tree.predict(data_test)
+    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.1,
              color="tab:blue", label=label)
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
-target_bagged_trees_predicted = bagged_trees.predict(data_test)
-plt.plot(data_test, target_bagged_trees_predicted,
+bagged_trees_predictions = bagged_trees.predict(data_test)
+plt.plot(data_test, bagged_trees_predictions,
          color="tab:orange", label="Predictions of ensemble")
 _ = plt.legend()
 
@@ -308,9 +310,9 @@ _ = bagging.fit(data_train, target_train)
 
 # %%
 for i, regressor in enumerate(bagging.estimators_):
-    target_regressor_predicted = regressor.predict(data_test)
+    regressor_predictions = regressor.predict(data_test)
     base_model_line = plt.plot(
-        data_test, target_regressor, linestyle="--", alpha=0.2,
+        data_test, regressor_predictions, linestyle="--", alpha=0.2,
         label="Predictions of base models" if i == 0 else None,
         color="tab:blue"
     )


### PR DESCRIPTION
/cc @glemaitre 

In particular this removes the swarmplot / pd.melt usage and instead uses a scatter plot with blue circle to more intuitively illustrate bootstrap resampling.

It also add bagged polynomial regression pipeline in the end.