### PR TITLE
Improve randomized search cv notebook

### DIFF
--- a/notebooks/parameter_tuning_randomized_search.ipynb
+++ b/notebooks/parameter_tuning_randomized_search.ipynb
@@ -145,8 +145,9 @@
     "\n",
     "model = Pipeline([\n",
     "    (\"preprocessor\", preprocessor),\n",
-    "    (\"classifier\",\n",
-    "     HistGradientBoostingClassifier(random_state=42, max_leaf_nodes=4))])\n",
+    "    (\"classifier\", HistGradientBoostingClassifier(random_state=42, max_leaf_nodes=4)),\n",
+    "])\n",
+    "\n",
     "model"
    ]
   },
@@ -229,7 +230,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we can define the randomized search using the different distributions."
+    "\n",
+    "Now, we can define the randomized search using the different distributions.\n",
+    "Executing 10 iterations of 5-fold cross-validation for random\n",
+    "parametrizations of this model on this dataset can take from 10 seconds to\n",
+    "several minutes, depending on the speed of the host computer and the number\n",
+    "of available processors."
    ]
   },
   {
@@ -238,6 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "from sklearn.model_selection import RandomizedSearchCV\n",
     "\n",
     "param_distributions = {\n",
@@ -245,11 +252,13 @@
     "    'classifier__learning_rate': loguniform(0.001, 10),\n",
     "    'classifier__max_leaf_nodes': loguniform_int(2, 256),\n",
     "    'classifier__min_samples_leaf': loguniform_int(1, 100),\n",
-    "    'classifier__max_bins': loguniform_int(2, 255)}\n",
+    "    'classifier__max_bins': loguniform_int(2, 255),\n",
+    "}\n",
     "\n",
     "model_random_search = RandomizedSearchCV(\n",
     "    model, param_distributions=param_distributions, n_iter=10,\n",
-    "    n_jobs=4, cv=5)\n",
+    "    cv=5, verbose=1,\n",
+    ")\n",
     "model_random_search.fit(data_train, target_train)"
    ]
   },
@@ -290,8 +299,9 @@
     "lines_to_next_cell": 2
    },
    "source": [
-    "We can inspect the results using the attributes `cv_results` as we previously\n",
-    "did."
+    "\n",
+    "We can inspect the results using the attributes `cv_results` as we did\n",
+    "previously."
    ]
   },
   {
@@ -404,6 +414,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "\n",
     "The parallel coordinates plot will display the values of the hyperparameters\n",
     "on different columns while the performance metric is color coded. Thus, we\n",
     "are able to quickly inspect if there is a range of hyperparameters which is\n",
@@ -415,15 +426,32 @@
     "spread the active ranges and improve the readability of the plot.</p>\n",
     "</div>\n",
     "\n",
-    "It is possible to **select a range of results by clicking and holding on\n",
-    "any axis** of the parallel coordinate plot. You can then slide (move)\n",
-    "the range selection and cross two selections to see the intersections."
+    "In particular for this hyper-parameter search, it is interesting to see that\n",
+    "the yellow lines (top performing models) all reach intermediate values for\n",
+    "the learning rate, that is, tick values between -2 and 0 which correspond to\n",
+    "learning rate values of 0.01 to 1.0 once we invert the log10 transform for\n",
+    "that axis.\n",
+    "\n",
+    "It is possible to **select a range of results by clicking and holding on any\n",
+    "axis** of the parallel coordinate plot. You can then slide (move) the range\n",
+    "selection and cross two selections to see the intersections. You can undo a\n",
+    "selection by clicking once again on the same axis.\n",
+    "\n",
+    "We also observe that it is not possible to select the highest performing\n",
+    "models by selecting lines of on the `max_bins` axis with tick values between\n",
+    "1 and 3.\n",
+    "\n",
+    "The other hyper-parameters are not very sensitive. We can check that if we\n",
+    "select the `learning_rate` axis tick values between -1.5 and -0.5 and\n",
+    "`max_bins` tick values between 5 and 8, we always select top performing\n",
+    "models, whatever the values of the other hyper-parameters."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "\n",
     "In this notebook, we have seen how randomized search offer a valuable\n",
     "alternative to grid-search when the number of hyperparameters to tune is more\n",
     "than two. It also alleviates the regularity imposed by the grid that might be\n",


### PR DESCRIPTION
This PR changes 2 things:

- first, only use the inner parallelism of HistGradientBoosting instead of process level parallism with `n_jobs=4` in the `RandomizedSearchCV` call itself. I noticed it caused oversubsubscription performance problems with our current configuration of `OMP_NUM_THREADS` and the jupyterhub docker spawner config
- secondly, be more explicit about how to analyze the plot.

The second point is based on the feedback of:

https://mooc-forums.inria.fr/moocsl/t/video-to-explain-how-to-use-the-interactive-parallel-coordinates-plot/2548

I know this is kind of partially answering the quiz but I think it is fine. The goal of the quiz is check that the student carefully read and understood the analysis and could reproduce it and refine it further.

I think having a video to redo this analysis would be a nice addition but this PR is already a net improvement I think.