### PR TITLE
Try to render plotly figures in the jupyterbook

### DIFF
--- a/jupyter-book/_config.yml
+++ b/jupyter-book/_config.yml
@@ -63,6 +63,10 @@ sphinx:
       .py:
         - jupytext.reads
         - fmt: py:percent
+    # Needed for plotly rendering:
+    # https://jupyterbook.org/interactive/interactive.html#plotly
+    html_js_files:
+      - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
 
 #######################################################################################
 # Launch button settings


### PR DESCRIPTION
I am not sure about the indentation level.

Source:

https://jupyterbook.org/interactive/interactive.html#plotly

Original report:

https://mooc-forums.inria.fr/moocsl/t/missing-figure-in-the-solution-of-ex-m3-02/2896/2