### PR TITLE
Pin jupyter-book to 0.10.2.

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,6 +8,6 @@ dependencies:
   - matplotlib-base
   - seaborn
   - plotly
-  - jupyter-book
+  - jupyter-book=0.10.2
   - jupytext
   - beautifulsoup4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ pandas>=1
 matplotlib
 seaborn
 plotly
-jupyter-book
+jupyter-book==0.10.2
 jupytext
 beautifulsoup4


### PR DESCRIPTION
0.11 is a breaking change that changes the format of _toc.yml see https://github.com/executablebooks/jupyter-book/blob/master/CHANGELOG.md#v0111.