### PR TITLE
Test more lenient cache key.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
             - v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-{{ .Branch }}
             - v1-master
+            - v1-
             - v1
+            - v
       - run:
           command: ./build_tools/circle/build_jupyter_book.sh
           no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
             - v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-{{ .Branch }}
             - v1-master
+            - v1
       - run:
           command: ./build_tools/circle/build_jupyter_book.sh
           no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,27 +10,11 @@ jobs:
       - OPENBLAS_NUM_THREADS: 2
       - MINICONDA_PATH: ~/miniconda
     steps:
-      - checkout
-      - run: ./build_tools/circle/checkout_merge_commit.sh
-      - run: ./build_tools/circle/checksum_python_files.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-{{ .Branch }}
             - v1-master
-            - v1-
-            - v1
-            - v
       - run:
-          command: ./build_tools/circle/build_jupyter_book.sh
-          no_output_timeout: 30m
-      - save_cache:
-          paths:
-            - jupyter-book/_build/.jupyter_cache
-          key: v1-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-      - store_artifacts:
-          path: jupyter-book/_build/html
-          destination: jupyter-book
+          command: echo test
 
 workflows:
   version: 2


### PR DESCRIPTION
For some reason the first build in a PR does not find the cache key from master. This means that the first commit build is slow (15-30 minutes). It is slightly annoying ... let's try something real quick.