### PR TITLE
Typos in linear_models_regularization.py?

### DIFF
--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -297,7 +297,7 @@ print(f"Mean squared error of linear regression model on the test set:\n"
       f"{test_error.mean():.3f} +/- {test_error.std():.3f}")
 
 # %% [markdown]
-# By optimizing `alpha`, we see that the training an testing scores are closed.
+# By optimizing `alpha`, we see that the training and testing scores are close.
 # It indicates that our model is not overfitting.
 #
 # When fitting the ridge regressor, we also requested to store the error found

--- a/python_scripts/logistic_regression_non_linear.py
+++ b/python_scripts/logistic_regression_non_linear.py
@@ -195,8 +195,8 @@ _ = plt.title("Decision boundary with a model using an RBF kernel")
 # classifier more expressive, exactly as we saw in regression.
 #
 # Keep in mind that adding flexibility to a model can also risk increasing
-# overfitting by making the decision function to sensitive to individual
+# overfitting by making the decision function to be sensitive to individual
 # (possibly noisy) data points of the training set. Here we can observe that
 # the decision functions remain smooth enough to preserve good generalization.
-# If you are curious, you can try repeated the above experiment with
+# If you are curious, you can try to repeat the above experiment with
 # `gamma=100` and look at the decision functions.

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -9,7 +9,7 @@
 # the number of parameters to tune is increasing. Also, the grid will imposed
 # a regularity during the search which might be problematic.
 #
-# In this notebook, we will present the another method to tune hyperparameters
+# In this notebook, we will present another method to tune hyperparameters
 # called randomized search.
 
 # %% [markdown]


### PR DESCRIPTION

Possible typos at line 300?
an -> and?
closed -> close?

https://github.com/inria/scikit-learn-mooc/blob/0074787609e1ec761f84c64ba5f3ba3a64a9553e/python_scripts/linear_models_regularization.py#L300