### PR TITLE
Replace statistical performance by generalization performance

### DIFF
--- a/python_scripts/02_numerical_pipeline_ex_01.py
+++ b/python_scripts/02_numerical_pipeline_ex_01.py
@@ -15,7 +15,7 @@
 # %% [markdown]
 # # 📝 Exercise M1.03
 #
-# The goal of this exercise is to compare the statistical performance of our
+# The goal of this exercise is to compare the generalization performance of our
 # classifier (81% accuracy) to some baseline classifiers that would ignore the
 # input data and instead make constant predictions.
 #
@@ -26,7 +26,7 @@
 # Use a `DummyClassifier` and do a train-test split to evaluate
 # its accuracy on the test set. This
 # [link](https://scikit-learn.org/stable/modules/model_evaluation.html#dummy-estimators)
-# shows a few examples of how to evaluate the statistical performance of these
+# shows a few examples of how to evaluate the generalization performance of these
 # baseline models.
 
 # %%

--- a/python_scripts/02_numerical_pipeline_hands_on.py
+++ b/python_scripts/02_numerical_pipeline_hands_on.py
@@ -210,7 +210,7 @@ model = LogisticRegression()
 model.fit(data_train, target_train)
 
 # %% [markdown]
-# We can also use the `score` method to check the model statistical performance
+# We can also use the `score` method to check the model generalization performance
 # on the test set.
 
 # %%
@@ -218,7 +218,7 @@ accuracy = model.score(data_test, target_test)
 print(f"Accuracy of logistic regression: {accuracy:.3f}")
 
 # %% [markdown]
-# Now the real question is: is this statistical performance relevant of a good
+# Now the real question is: is this generalization performance relevant of a good
 # predictive model? Find out by solving the next exercise!
 #
 # In this notebook, we learned to:

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -21,7 +21,7 @@
 # In particular we will highlight:
 #
 # * the scikit-learn API: `.fit(X, y)`/`.predict(X)`/`.score(X, y)`;
-# * how to evaluate the statistical performance of a model with a train-test
+# * how to evaluate the generalization performance of a model with a train-test
 #   split.
 #
 # ## Loading the dataset with Pandas
@@ -177,7 +177,7 @@ print(f"Number of correct prediction: "
 # ## Train-test data split
 #
 # When building a machine learning model, it is important to evaluate the
-# trained model on data that was not used to fit it, as generalization is
+# trained model on data that was not used to fit it, as **generalization** is
 # more than memorization (meaning we want a rule that generalizes to new data,
 # without comparing to data we memorized).
 # It is harder to conclude on never-seen instances than on already seen ones.
@@ -235,17 +235,17 @@ print(f"The test accuracy using a {model_name} is "
 # on the training set, we find that this evaluation was indeed optimistic
 # compared to the score obtained on an held-out test set.
 #
-# It shows the importance to always testing the statistical performance of
+# It shows the importance to always testing the generalization performance of
 # predictive models on a different set than the one used to train these models.
 # We will discuss later in more details how predictive models should be
 # evaluated.
 
 # %% [markdown]
 # ```{note}
-# In this MOOC, we will refer to **statistical performance** of a model when
+# In this MOOC, we will refer to **generalization performance** of a model when
 # referring to the test score or test error obtained by comparing the
 # prediction of a model and the true targets. Equivalent terms for
-# **statistical performance** are predictive performance and generalization
+# **generalization performance** are predictive performance and statistical
 # performance. We will refer to **computational performance** of a predictive
 # model when accessing the computational costs of training a predictive model
 # or using it to make predictions.
@@ -255,7 +255,7 @@ print(f"The test accuracy using a {model_name} is "
 # In this notebook we:
 #
 # * fitted a **k-nearest neighbors** model on a training dataset;
-# * evaluated its statistical performance on the testing data;
+# * evaluated its generalization performance on the testing data;
 # * introduced the scikit-learn API `.fit(X, y)` (to train a model),
 #   `.predict(X)` (to make predictions) and `.score(X, y)`
 #   (to evaluate a model).

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -22,7 +22,7 @@
 # * an example of preprocessing, namely **scaling numerical variables**;
 # * using a scikit-learn **pipeline** to chain preprocessing and model
 #   training;
-# * assessing the statistical performance of our model via **cross-validation**
+# * assessing the generalization performance of our model via **cross-validation**
 #   instead of a single train-test split.
 #
 # ## Data preparation
@@ -258,7 +258,7 @@ predicted_target[:5]
 #
 # As a shorthand, we can check the score of the full predictive pipeline
 # calling the method `model.score`. Thus, let's check the computational and
-# statistical performance of such a predictive pipeline.
+# generalization performance of such a predictive pipeline.
 
 # %%
 model_name = model.__class__.__name__
@@ -287,7 +287,7 @@ print(f"The accuracy using a {model_name} is {score:.3f} "
 # %% [markdown]
 # We see that scaling the data before training the logistic regression was
 # beneficial in terms of computational performance. Indeed, the number of
-# iterations decreased as well as the training time. The statistical
+# iterations decreased as well as the training time. The generalization
 # performance did not change since both models converged.
 #
 # ```{warning}
@@ -311,9 +311,9 @@ print(f"The accuracy using a {model_name} is {score:.3f} "
 #
 # Instead, we can use cross-validation. Cross-validation consists of repeating
 # the procedure such that the training and testing sets are different each
-# time. Statistical performance metrics are collected for each repetition and
+# time. Generalization performance metrics are collected for each repetition and
 # then aggregated. As a result we can get an estimate of the variability of the
-# model's statistical performance.
+# model's generalization performance.
 #
 # Note that there exists several cross-validation strategies, each of them
 # defines how to repeat the `fit`/`score` procedure. In this section, we will
@@ -381,10 +381,10 @@ print("The mean cross-validation accuracy is: "
 
 # %% [markdown]
 # Note that by computing the standard-deviation of the cross-validation scores,
-# we can estimate the uncertainty of our model statistical performance. This is
+# we can estimate the uncertainty of our model generalization performance. This is
 # the main advantage of cross-validation and can be crucial in practice, for
 # example when comparing different models to figure out whether one is better
-# than the other or whether the statistical performance differences are within
+# than the other or whether the generalization performance differences are within
 # the uncertainty.
 #
 # In this particular case, only the first 2 decimals seem to be trustworthy. If
@@ -397,4 +397,4 @@ print("The mean cross-validation accuracy is: "
 #
 # * seen the importance of **scaling numerical variables**;
 # * used a **pipeline** to chain scaling and logistic regression training;
-# * assessed the statistical performance of our model via **cross-validation**.
+# * assessed the generalization performance of our model via **cross-validation**.

--- a/python_scripts/02_numerical_pipeline_sol_01.py
+++ b/python_scripts/02_numerical_pipeline_sol_01.py
@@ -27,7 +27,7 @@
 # Use a `DummyClassifier` and do a train-test split to evaluate
 # its accuracy on the test set. This
 # [link](https://scikit-learn.org/stable/modules/model_evaluation.html#dummy-estimators)
-# shows a few examples of how to evaluate the statistical performance of these
+# shows a few examples of how to evaluate the generalization performance of these
 # baseline models.
 
 # %%
@@ -65,7 +65,7 @@ data_numeric_train, data_numeric_test, target_train, target_test = \
 
 # %% [markdown]
 # We will first create a dummy classifier which will always predict the
-# high revenue class, i.e. `" >50K"`, and check the statistical
+# high revenue class, i.e. `" >50K"`, and check the generalization
 # performance.
 
 # %%
@@ -80,7 +80,7 @@ print(f"Accuracy of a model predicting only high revenue: {score:.3f}")
 
 # %% [markdown]
 # We clearly see that the score is below 0.5 which might be surprising at
-# first. We will now check the statistical performance of a model which always
+# first. We will now check the generalization performance of a model which always
 # predict the low revenue class, i.e. `" <=50K"`.
 
 # %%

--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -275,7 +275,7 @@ pd.DataFrame(data_encoded, columns=columns_encoded).head()
 #
 # We can now integrate this encoder inside a machine learning pipeline like we
 # did with numerical data: let's train a linear classifier on the encoded data
-# and check the statistical performance of this machine learning pipeline using
+# and check the generalization performance of this machine learning pipeline using
 # cross-validation.
 #
 # Before we create the pipeline, we have to linger on the `native-country`.
@@ -327,7 +327,7 @@ model = make_pipeline(
 # ```
 
 # %% [markdown]
-# Finally, we can check the model's statistical performance only using the
+# Finally, we can check the model's generalization performance only using the
 # categorical columns.
 
 # %%

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -218,7 +218,7 @@ print("The mean cross-validation accuracy is: "
 # However, it is often useful to check whether more complex models such as an
 # ensemble of decision trees can lead to higher predictive performance. In this
 # section we will use such a model called **gradient-boosting trees** and
-# evaluate its statistical performance. More precisely, the scikit-learn model
+# evaluate its generalization performance. More precisely, the scikit-learn model
 # we will use is called `HistGradientBoostingClassifier`. Note that boosting
 # models will be covered in more detail in a future module.
 #
@@ -246,7 +246,7 @@ preprocessor = ColumnTransformer([
 model = make_pipeline(preprocessor, HistGradientBoostingClassifier())
 
 # %% [markdown]
-# Now that we created our model, we can check its statistical performance.
+# Now that we created our model, we can check its generalization performance.
 
 # %%
 # %%time

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -21,7 +21,7 @@
 #
 # To do so, let's try to use `OrdinalEncoder` to preprocess the categorical
 # variables. This preprocessor is assembled in a pipeline with
-# `LogisticRegression`. The statistical performance of the pipeline can be
+# `LogisticRegression`. The generalization performance of the pipeline can be
 # evaluated by cross-validation and then compared to the score obtained when
 # using `OneHotEncoder` or to some other baseline score.
 #
@@ -78,7 +78,7 @@ from sklearn.model_selection import cross_validate
 # Write your code here.
 
 # %% [markdown]
-# Now, we would like to compare the statistical performance of our previous
+# Now, we would like to compare the generalization performance of our previous
 # model with a new model where instead of using an `OrdinalEncoder`, we will
 # use a `OneHotEncoder`. Repeat the model evaluation using cross-validation.
 # Compare the score of both models and conclude on the impact of choosing a

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -21,7 +21,7 @@
 #
 # To do so, let's try to use `OrdinalEncoder` to preprocess the categorical
 # variables. This preprocessor is assembled in a pipeline with
-# `LogisticRegression`. The statistical performance of the pipeline can be
+# `LogisticRegression`. The generalization performance of the pipeline can be
 # evaluated by cross-validation and then compared to the score obtained when
 # using `OneHotEncoder` or to some other baseline score.
 #
@@ -103,7 +103,7 @@ print("The mean cross-validation accuracy is: "
       f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
-# Now, we would like to compare the statistical performance of our previous
+# Now, we would like to compare the generalization performance of our previous
 # model with a new model where instead of using an `OrdinalEncoder`, we will
 # use a `OneHotEncoder`. Repeat the model evaluation using cross-validation.
 # Compare the score of both models and conclude on the impact of choosing a

--- a/python_scripts/cross_validation_baseline.py
+++ b/python_scripts/cross_validation_baseline.py
@@ -1,7 +1,7 @@
 # %% [markdown]
 # # Comparing results with baseline and chance level
 #
-# In this notebook, we present how to compare the statistical performance of a
+# In this notebook, we present how to compare the generalization performance of a
 # model to a minimal baseline.
 #
 # Indeed, in the previous notebook, we compared the testing error by
@@ -68,8 +68,8 @@ result_dummy = cross_validate(dummy, data, target,
 errors_dummy = pd.Series(-result_dummy["test_score"], name="Dummy error")
 
 # %% [markdown]
-# Finally, we will evaluate the statistical performance of the second baseline.
-# This baseline will provide the statistical performance of the chance level.
+# Finally, we will evaluate the generalization performance of the second baseline.
+# This baseline will provide the generalization performance of the chance level.
 # Indeed, we will train a decision tree on some training data and evaluate the
 # same tree on data where the target vector has been randomized.
 
@@ -99,7 +99,7 @@ plt.xlabel("Mean absolute error (k$)")
 _ = plt.title("Distribution of the testing errors")
 
 # %% [markdown]
-# We see that even if the statistical performance of our model is far from
+# We see that even if the generalization performance of our model is far from
 # being good, it is better than the two baselines. Besides, we see that the
 # dummy regressor is better than a chance level regressor.
 #

--- a/python_scripts/cross_validation_ex_01.py
+++ b/python_scripts/cross_validation_ex_01.py
@@ -51,7 +51,7 @@ target = blood_transfusion["Class"]
 # Write your code here.
 
 # %% [markdown]
-# Evaluate the statistical performance of your model by cross-validation with a
+# Evaluate the generalization performance of your model by cross-validation with a
 # `ShuffleSplit` scheme. Thus, you can use
 # [`sklearn.model_selection.cross_validate`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html)
 # and pass a [`sklearn.model_selection.ShuffleSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ShuffleSplit.html)

--- a/python_scripts/cross_validation_ex_04.py
+++ b/python_scripts/cross_validation_ex_04.py
@@ -21,7 +21,7 @@ data, target = load_digits(return_X_y=True, as_frame=True)
 # %% [markdown]
 # Then, create a a `KFold` object making sure that the data will not be
 # shuffled during the cross-validation. Use the previous model, data, and
-# cross-validation strategy defined to estimate the statistical performance of
+# cross-validation strategy defined to estimate the generalization performance of
 # the model.
 
 # %%

--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -149,7 +149,7 @@ print(f"The average accuracy is "
       f"{test_score.std():.3f}")
 
 # %% [markdown]
-# We see that this strategy is less optimistic regarding the model statistical
+# We see that this strategy is less optimistic regarding the model generalization
 # performance. However, this is the most reliable if our goal is to make
 # handwritten digits recognition writers independent. Besides, we can as well
 # see that the standard deviation was reduced.

--- a/python_scripts/cross_validation_learning_curve.py
+++ b/python_scripts/cross_validation_learning_curve.py
@@ -34,7 +34,7 @@ regressor = DecisionTreeRegressor()
 # ## Learning curve
 #
 # To understand the impact of the number of samples available for training on
-# the statistical performance of a predictive model, it is possible to
+# the generalization performance of a predictive model, it is possible to
 # synthetically reduce the number of samples used to train the predictive model
 # and check the training and testing errors.
 #
@@ -44,7 +44,7 @@ regressor = DecisionTreeRegressor()
 # number of training samples. This curve is called the **learning curve**.
 #
 # It gives information regarding the benefit of adding new training samples
-# to improve a model's statistical performance.
+# to improve a model's generalization performance.
 #
 # Let's compute the learning curve for a decision tree and vary the
 # proportion of the training set from 10% to 100%.

--- a/python_scripts/cross_validation_nested.py
+++ b/python_scripts/cross_validation_nested.py
@@ -5,7 +5,7 @@
 # should be used when you want to both evaluate a model and tune the
 # model's hyperparameters.
 #
-# Cross-validation is a powerful tool to evaluate the statistical performance
+# Cross-validation is a powerful tool to evaluate the generalization performance
 # of a model. It is also used to select the best model from a pool of models.
 # This pool of models can be the same family of predictor but with different
 # parameters. In this case, we call this procedure **hyperparameter tuning**.
@@ -98,7 +98,7 @@ print(f"The mean score using nested cross-validation is: "
 
 # %% [markdown]
 # In the example above, the reported score is more trustful and should be close
-# to production's expected statistical performance.
+# to production's expected generalization performance.
 #
 # We will illustrate the difference between the nested and non-nested
 # cross-validation scores to show that the latter one will be too optimistic in
@@ -147,10 +147,10 @@ _ = plt.title("Comparison of mean accuracy obtained on the test sets with\n"
               "and without nested cross-validation")
 
 # %% [markdown]
-# We observe that the model's statistical performance with the nested
+# We observe that the model's generalization performance with the nested
 # cross-validation is not as good as the non-nested cross-validation.
 #
 # As a conclusion, when optimizing parts of the machine learning pipeline (e.g.
 # hyperparameter, transform, etc.), one needs to use nested cross-validation to
-# evaluate the statistical performance of the predictive model. Otherwise, the
+# evaluate the generalization performance of the predictive model. Otherwise, the
 # results obtained without nested cross-validation are over-optimistic.

--- a/python_scripts/cross_validation_sol_01.py
+++ b/python_scripts/cross_validation_sol_01.py
@@ -57,7 +57,7 @@ from sklearn.svm import SVC
 model = make_pipeline(StandardScaler(), SVC())
 
 # %% [markdown]
-# Evaluate the statistical performance of your model by cross-validation with a
+# Evaluate the generalization performance of your model by cross-validation with a
 # `ShuffleSplit` scheme. Thus, you can use
 # [`sklearn.model_selection.cross_validate`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html)
 # and pass a [`sklearn.model_selection.ShuffleSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ShuffleSplit.html)

--- a/python_scripts/cross_validation_stratification.py
+++ b/python_scripts/cross_validation_stratification.py
@@ -43,7 +43,7 @@ for train_index, test_index in cv.split(data_random):
 # for the last split. In the end, all samples have been used in testing at
 # least once among the different splits.
 #
-# Now, let's apply this strategy to check the statistical performance of our
+# Now, let's apply this strategy to check the generalization performance of our
 # model.
 
 # %%

--- a/python_scripts/cross_validation_time.py
+++ b/python_scripts/cross_validation_time.py
@@ -56,7 +56,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 # %% [markdown]
 # We will use a decision tree regressor that we expect to overfit and thus not
 # generalize to unseen data. We will use a `ShuffleSplit` cross-validation to
-# check the statistical performance of our model.
+# check the generalization performance of our model.
 #
 # Let's first define our model
 
@@ -85,7 +85,7 @@ print(f"The mean R2 is: "
       f"{test_score.mean():.2f} +/- {test_score.std():.2f}")
 
 # %% [markdown]
-# Surprisingly, we get outstanding statistical performance. We will investigate
+# Surprisingly, we get outstanding generalization performance. We will investigate
 # and find the reason for such good results with a model that is expected to
 # fail. We previously mentioned that `ShuffleSplit` is an iterative
 # cross-validation scheme that shuffles data and split. We will simplify this
@@ -99,7 +99,7 @@ target_predicted = regressor.predict(data_test)
 target_predicted = pd.Series(target_predicted, index=target_test.index)
 
 # %% [markdown]
-# Let's check the statistical performance of our model on this split.
+# Let's check the generalization performance of our model on this split.
 
 # %%
 from sklearn.metrics import r2_score
@@ -163,7 +163,7 @@ _ = plt.title("Model predictions using a split without shuffling")
 # %% [markdown]
 # We see that our model cannot predict anything because it doesn't have samples
 # around the testing sample. Let's check how we could have made a proper
-# cross-validation scheme to get a reasonable statistical performance estimate.
+# cross-validation scheme to get a reasonable generalization performance estimate.
 #
 # One solution would be to group the samples into time blocks, e.g. by quarter,
 # and predict each group's information by using information from the other

--- a/python_scripts/cross_validation_train_test.py
+++ b/python_scripts/cross_validation_train_test.py
@@ -62,7 +62,7 @@ regressor = DecisionTreeRegressor(random_state=0)
 regressor.fit(data, target)
 
 # %% [markdown]
-# After training the regressor, we would like to know its potential statistical
+# After training the regressor, we would like to know its potential generalization
 # performance once deployed in production. For this purpose, we use the mean
 # absolute error, which gives us an error in the native unit, i.e. k\$.
 
@@ -158,7 +158,7 @@ print(f"The testing error of our model is {score:.2f} k$")
 # **Cross-validation** allows estimating the robustness of a predictive model
 # by repeating the splitting procedure. It will give several training and
 # testing errors and thus some **estimate of the variability of the
-# model statistical performance**.
+# model generalization performance**.
 #
 # There are different cross-validation strategies, for now we are going to
 # focus on one called "shuffle-split". At each iteration of this strategy we:
@@ -170,9 +170,9 @@ print(f"The testing error of our model is {score:.2f} k$")
 #
 # We repeat this procedure `n_splits` times. Using `n_splits=40` means that we
 # will train 40 models in total and all of them will be discarded: we just
-# record their statistical performance on each variant of the test set.
+# record their generalization performance on each variant of the test set.
 #
-# To evaluate the statistical performance of our regressor, we can use
+# To evaluate the generalization performance of our regressor, we can use
 # [`sklearn.model_selection.cross_validate`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html)
 # with a
 # [`sklearn.model_selection.ShuffleSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ShuffleSplit.html)
@@ -343,4 +343,4 @@ scores
 # * the necessity of splitting the data into a train and test set;
 # * the meaning of the training and testing errors;
 # * the overall cross-validation framework with the possibility to study
-#   statistical performance variations;
+#   generalization performance variations.

--- a/python_scripts/cross_validation_validation_curve.py
+++ b/python_scripts/cross_validation_validation_curve.py
@@ -32,7 +32,7 @@ regressor = DecisionTreeRegressor()
 # %% [markdown]
 # ## Overfitting vs. underfitting
 #
-# To better understand the statistical performance of our model and maybe find
+# To better understand the generalization performance of our model and maybe find
 # insights on how to improve it, we will compare the testing error with the
 # training error. Thus, we need to compute the error on the training set,
 # which is possible using the `cross_validate` function.

--- a/python_scripts/datasets_blood_transfusion.py
+++ b/python_scripts/datasets_blood_transfusion.py
@@ -90,7 +90,7 @@ target.value_counts(normalize=True)
 # important: a classifier that would predict always this `"not donated"` class
 # would achieve an accuracy of 76% of good classification without using any
 # information from the data itself. This issue is known as class imbalance. One
-# should take care about the statistical performance metric used to evaluate a
+# should take care about the generalization performance metric used to evaluate a
 # model as well as the predictive model chosen itself.
 #
 # Now, let's have a naive analysis to see if there is a link between features

--- a/python_scripts/ensemble_adaboost.py
+++ b/python_scripts/ensemble_adaboost.py
@@ -213,7 +213,7 @@ print(f"Error of each classifier: {adaboost.estimator_errors_}")
 # focuses on different samples. Looking at the weights of each learner, we see
 # that the ensemble gives the highest weight to the first classifier. This
 # indeed makes sense when we look at the errors of each classifier. The first
-# classifier also has the highest classification statistical performance.
+# classifier also has the highest classification generalization performance.
 #
 # While AdaBoost is a nice algorithm to demonstrate the internal machinery of
 # boosting algorithms, it is not the most efficient.

--- a/python_scripts/ensemble_ex_01.py
+++ b/python_scripts/ensemble_ex_01.py
@@ -25,7 +25,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 # %% [markdown]
 # Create a `BaggingRegressor` and provide a `DecisionTreeRegressor`
 # to its parameter `base_estimator`. Train the regressor and evaluate its
-# statistical performance on the testing set using the mean absolute error.
+# generalization performance on the testing set using the mean absolute error.
 
 # %%
 # Write your code here.

--- a/python_scripts/ensemble_ex_02.py
+++ b/python_scripts/ensemble_ex_02.py
@@ -25,7 +25,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 
 # %% [markdown]
 # Create a random forest containing three trees. Train the forest and
-# check the statistical performance on the testing set in terms of mean
+# check the generalization performance on the testing set in terms of mean
 # absolute error.
 
 # %%

--- a/python_scripts/ensemble_ex_03.py
+++ b/python_scripts/ensemble_ex_03.py
@@ -44,7 +44,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 # %% [markdown]
 # Plotting the validation curve, we can see that AdaBoost is not immune against
 # overfitting. Indeed, there is an optimal number of estimators to be found.
-# Adding too many estimators is detrimental for the statistical performance of
+# Adding too many estimators is detrimental for the generalization performance of
 # the model.
 
 # %% [markdown]

--- a/python_scripts/ensemble_ex_04.py
+++ b/python_scripts/ensemble_ex_04.py
@@ -6,7 +6,7 @@
 # * verify if a GBDT tends to overfit if the number of estimators is not
 #   appropriate as previously seen for AdaBoost;
 # * use the early-stopping strategy to avoid adding unnecessary trees, to
-#   get the best statistical performances.
+#   get the best generalization performances.
 #
 # We will use the California housing dataset to conduct our experiments.
 
@@ -28,8 +28,8 @@ data_train, data_test, target_train, target_test = train_test_split(
 # %% [markdown]
 # Similarly to the previous exercise, create a gradient boosting decision tree
 # and create a validation curve to assess the impact of the number of trees
-# on the statistical performance of the model. Use the mean absolute error
-# to assess the statistical performance of the model.
+# on the generalization performance of the model. Use the mean absolute error
+# to assess the generalization performance of the model.
 
 # %%
 # Write your code here.
@@ -41,14 +41,14 @@ data_train, data_test, target_train, target_test = train_test_split(
 #
 # To avoid adding new unnecessary tree, gradient boosting offers an
 # early-stopping option. Internally, the algorithm will use an out-of-sample
-# set to compute the statistical performance of the model at each addition of a
-# tree. Thus, if the statistical performance are not improving for several
+# set to compute the generalization performance of the model at each addition of a
+# tree. Thus, if the generalization performance are not improving for several
 # iterations, it will stop adding trees.
 #
 # Now, create a gradient-boosting model with `n_estimators=1000`. This number
 # of trees will be too large. Change the parameter `n_iter_no_change` such
 # that the gradient boosting fitting will stop after adding 5 trees that do not
-# improve the overall statistical performance.
+# improve the overall generalization performance.
 
 # %%
 # Write your code here.

--- a/python_scripts/ensemble_gradient_boosting.py
+++ b/python_scripts/ensemble_gradient_boosting.py
@@ -229,7 +229,7 @@ print(f"Error of the tree: {target_true - y_pred_first_and_second_tree:.3f}")
 # (i.e. the second tree corrects the first tree's error, while the third tree
 # corrects the second tree's error and so on.)
 #
-# We will compare the statistical performance of random-forest and gradient
+# We will compare the generalization performance of random-forest and gradient
 # boosting on the California housing dataset.
 
 # %%

--- a/python_scripts/ensemble_hist_gradient_boosting.py
+++ b/python_scripts/ensemble_hist_gradient_boosting.py
@@ -18,7 +18,7 @@
 # depth", which you can refer to.
 #
 # To accelerate the gradient-boosting algorithm, one could reduce the number of
-# splits to be evaluated. As a consequence, the statistical performance of such
+# splits to be evaluated. As a consequence, the generalization performance of such
 # a tree would be reduced. However, since we are combining several trees in a
 # gradient-boosting, we can add more estimators to overcome this issue.
 #
@@ -118,7 +118,7 @@ print(f"Average score time: "
 
 # %% [markdown]
 # Here, we see that the fit time has been drastically reduced but that the
-# statistical performance of the model is identical. Scikit-learn provides a
+# generalization performance of the model is identical. Scikit-learn provides a
 # specific classes which are even more optimized for large dataset, called
 # `HistGradientBoostingClassifier` and `HistGradientBoostingRegressor`. Each
 # feature in the dataset `data` is first binned by computing histograms, which

--- a/python_scripts/ensemble_hyperparameters.py
+++ b/python_scripts/ensemble_hyperparameters.py
@@ -18,9 +18,9 @@
 # ## Random forest
 #
 # The main parameter to tune for random forest is the `n_estimators` parameter.
-# In general, the more trees in the forest, the better the statistical
+# In general, the more trees in the forest, the better the generalization
 # performance will be. However, it will slow down the fitting and prediction
-# time. The goal is to balance computing time and statistical performance when
+# time. The goal is to balance computing time and generalization performance when
 # setting the number of estimators when putting such learner in production.
 #
 # The `max_depth` parameter could also be tuned. Sometimes, there is no need
@@ -62,7 +62,7 @@ cv_results[columns].sort_values(by="rank_test_score")
 
 # %% [markdown]
 # We can observe that in our grid-search, the largest `max_depth` together
-# with the largest `n_estimators` led to the best statistical performance.
+# with the largest `n_estimators` led to the best generalization performance.
 #
 # ## Gradient-boosting decision trees
 #

--- a/python_scripts/ensemble_introduction.py
+++ b/python_scripts/ensemble_introduction.py
@@ -22,7 +22,7 @@ data, target = fetch_california_housing(as_frame=True, return_X_y=True)
 target *= 100  # rescale the target in k$
 
 # %% [markdown]
-# We will check the statistical performance of decision tree regressor with
+# We will check the generalization performance of decision tree regressor with
 # default parameters.
 
 # %%
@@ -74,7 +74,7 @@ print(f"R2 score obtained by cross-validation: "
 
 # %% [markdown]
 # We see that optimizing the hyperparameters will have a positive effect
-# on the statistical performance. However, it comes with a higher computational
+# on the generalization performance. However, it comes with a higher computational
 # cost.
 
 # %% [markdown]
@@ -88,7 +88,7 @@ print(f"R2 score obtained by cross-validation: "
 # predictions of all these base regressors will be combined by averaging.
 #
 # Here, we will use 20 decision trees and check the fitting time as well as the
-# statistical performance on the left-out testing data. It is important to note
+# generalization performance on the left-out testing data. It is important to note
 # that we are not going to tune any parameter of the decision tree.
 
 # %%
@@ -106,13 +106,13 @@ print(f"R2 score obtained by cross-validation: "
       f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
-# Without searching for optimal hyperparameters, the overall statistical
+# Without searching for optimal hyperparameters, the overall generalization
 # performance of the bagging regressor is better than a single decision tree.
 # In addition, the computational cost is reduced in comparison of seeking
 # for the optimal hyperparameters.
 #
 # This shows the motivation behind the use of an ensemble learner: it gives a
-# relatively good baseline with decent statistical performance without any
+# relatively good baseline with decent generalization performance without any
 # parameter tuning.
 #
 # Now, we will discuss in detail two ensemble families: bagging and

--- a/python_scripts/ensemble_random_forest.py
+++ b/python_scripts/ensemble_random_forest.py
@@ -68,7 +68,7 @@ preprocessor = make_column_transformer(
 # %% [markdown]
 #
 # We will first give a simple example where we will train a single decision
-# tree classifier and check its statistical performance via cross-validation.
+# tree classifier and check its generalization performance via cross-validation.
 
 # %%
 from sklearn.pipeline import make_pipeline

--- a/python_scripts/ensemble_sol_01.py
+++ b/python_scripts/ensemble_sol_01.py
@@ -25,7 +25,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 # %% [markdown]
 # Create a `BaggingRegressor` and provide a `DecisionTreeRegressor`
 # to its parameter `base_estimator`. Train the regressor and evaluate its
-# statistical performance on the testing set using the mean absolute error.
+# generalization performance on the testing set using the mean absolute error.
 
 # %%
 from sklearn.metrics import mean_absolute_error

--- a/python_scripts/ensemble_sol_02.py
+++ b/python_scripts/ensemble_sol_02.py
@@ -25,7 +25,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 
 # %% [markdown]
 # Create a random forest containing three trees. Train the forest and
-# check the statistical performance on the testing set in terms of mean
+# check the generalization performance on the testing set in terms of mean
 # absolute error.
 
 # %%

--- a/python_scripts/ensemble_sol_03.py
+++ b/python_scripts/ensemble_sol_03.py
@@ -96,7 +96,7 @@ _ = plt.title("Validation curve for RandomForest regressor")
 
 # %% [markdown]
 # In contrary to the AdaBoost regressor, we can see that increasing the number
-# trees in the forest will increase the statistical performance (by decreasing
+# trees in the forest will increase the generalization performance (by decreasing
 # the mean absolute error) of the random forest. In fact, a random forest has
 # less chance to suffer from overfitting than AdaBoost when increasing the
 # number of estimators.

--- a/python_scripts/ensemble_sol_04.py
+++ b/python_scripts/ensemble_sol_04.py
@@ -6,7 +6,7 @@
 # * verify if a GBDT tends to overfit if the number of estimators is not
 #   appropriate as previously seen for AdaBoost;
 # * use the early-stopping strategy to avoid adding unnecessary trees, to
-#   get the best statistical performances.
+#   get the best generalization performances.
 #
 # we will use the California housing dataset to conduct our experiments.
 
@@ -28,8 +28,8 @@ data_train, data_test, target_train, target_test = train_test_split(
 # %% [markdown]
 # Similarly to the previous exercise, create a gradient boosting decision tree
 # and create a validation curve to assess the impact of the number of trees
-# on the statistical performance of the model. Use the mean absolute error
-# to assess the statistical performance of the model.
+# on the generalization performance of the model. Use the mean absolute error
+# to assess the generalization performance of the model.
 
 # %%
 import numpy as np
@@ -77,14 +77,14 @@ _ = plt.title("Validation curve for GBDT regressor")
 #
 # To avoid adding new unnecessary tree, gradient boosting offers an
 # early-stopping option. Internally, the algorithm will use an out-of-sample
-# set to compute the statistical performance of the model at each addition of a
-# tree. Thus, if the statistical performance are not improving for several
+# set to compute the generalization performance of the model at each addition of a
+# tree. Thus, if the generalization performance are not improving for several
 # iterations, it will stop adding trees.
 #
 # Now, create a gradient-boosting model with `n_estimators=1000`. This number
 # of trees will be too large. Change the parameter `n_iter_no_change` such
 # that the gradient boosting fitting will stop after adding 5 trees that do not
-# improve the overall statistical performance.
+# improve the overall generalization performance.
 
 # %%
 gbdt = GradientBoostingRegressor(n_estimators=1000, n_iter_no_change=5)

--- a/python_scripts/feature_selection_ex_01.py
+++ b/python_scripts/feature_selection_ex_01.py
@@ -16,7 +16,7 @@
 #
 # This type of dimensionality is typical in bioinformatics when dealing with
 # RNA-seq. However, we will use completely randomized features such that we
-# don't have a link between the data and the target. Thus, the statistical
+# don't have a link between the data and the target. Thus, the generalization
 # performance of any machine learning model should not perform better than the
 # chance-level.
 
@@ -70,7 +70,7 @@ import numpy as np
 #
 # Thus, start by creating a pipeline with the feature selector and the logistic
 # regression. Then, use cross-validation to get an estimate of the uncertainty
-# of your model statistical performance.
+# of your model generalization performance.
 
 # %%
 # Write your code here.

--- a/python_scripts/feature_selection_introduction.py
+++ b/python_scripts/feature_selection_introduction.py
@@ -114,7 +114,7 @@ _ = plt.title("Time to make prediction")
 # We can draw the same conclusions for both training and scoring elapsed time:
 # selecting the most informative features speed-up our pipeline.
 #
-# Of course, such speed-up is beneficial only if the statistical performance in
+# Of course, such speed-up is beneficial only if the generalization performance in
 # terms of metrics remain the same. Let's check the testing score.
 
 # %%
@@ -123,7 +123,7 @@ plt.xlabel("Accuracy score")
 _ = plt.title("Test score via cross-validation")
 
 # %% [markdown]
-# We can observe that the model's statistical performance selecting a subset of
+# We can observe that the model's generalization performance selecting a subset of
 # features decreases compared with the model using all available features.
 # Since we generated the dataset, we can infer that the decrease is because of
 # the selection. The feature selection algorithm did not choose the two
@@ -145,7 +145,7 @@ for idx, pipeline in enumerate(cv_results_with_selection["estimator"]):
 # We see that the feature `53` is always selected while the other feature
 # varies depending on the cross-validation fold.
 #
-# If we would like to keep our score with similar statistical performance, we
+# If we would like to keep our score with similar generalization performance, we
 # could choose another metric to perform the test or select more features. For
 # instance, we could select the number of features based on a specific
 # percentile of the highest scores. Besides, we should keep in mind that we

--- a/python_scripts/feature_selection_sol_01.py
+++ b/python_scripts/feature_selection_sol_01.py
@@ -16,7 +16,7 @@
 #
 # This type of dimensionality is typical in bioinformatics when dealing with
 # RNA-seq. However, we will use completely randomized features such that we
-# don't have a link between the data and the target. Thus, the statistical
+# don't have a link between the data and the target. Thus, the generalization
 # performance of any machine-learning model should not perform better than the
 # chance-level.
 
@@ -105,7 +105,7 @@ print(f"The mean accuracy is: {test_score:.3f}")
 #
 # Thus, start by creating a pipeline with the feature selector and the logistic
 # regression. Then, use cross-validation to get an estimate of the uncertainty
-# of your model statistical performance.
+# of your model generalization performance.
 
 # %%
 from sklearn.pipeline import make_pipeline

--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -68,7 +68,7 @@ print(f"Mean squared error of linear regression model on the test set:\n"
       f"{test_error.mean():.3f} +/- {test_error.std():.3f}")
 
 # %% [markdown]
-# The score on the training set is much better. This statistical performance
+# The score on the training set is much better. This generalization performance
 # gap between the training and testing score is an indication that our model
 # overfitted our training set.
 #
@@ -319,7 +319,7 @@ _ = plt.title("Error obtained by cross-validation")
 
 # %% [markdown]
 # As we can see, regularization is just like salt in cooking: one must balance
-# its amount to get the best statistical performance. We can check if the best
+# its amount to get the best generalization performance. We can check if the best
 # `alpha` found is stable across the cross-validation fold.
 
 # %%

--- a/python_scripts/logistic_regression_non_linear.py
+++ b/python_scripts/logistic_regression_non_linear.py
@@ -100,7 +100,7 @@ linear_model.fit(data_moons, target_moons)
 # on the same dataset without splitting the dataset into a training set and a
 # testing set. While this is a bad practice, we use it for the sake of
 # simplicity to depict the model behavior. Always use cross-validation when
-# you want to assess the statistical performance of a machine-learning model.
+# you want to assess the generalization performance of a machine-learning model.
 # ```
 
 # %% [markdown]

--- a/python_scripts/metrics_classification.py
+++ b/python_scripts/metrics_classification.py
@@ -2,7 +2,7 @@
 # # Classification
 #
 # This notebook aims at giving an overview of the classification metrics that
-# can be used to evaluate the predictive model statistical performance. We can
+# can be used to evaluate the predictive model generalization performance. We can
 # recall that in a classification setting, the vector `target` is categorical
 # rather than continuous.
 #
@@ -100,7 +100,7 @@ target_test == target_predicted
 # In the comparison above, a `True` value means that the value predicted by our
 # classifier is identical to the real value, while a `False` means that our
 # classifier made a mistake. One way of getting an overall rate representing
-# the statistical performance of our classifier would be to compute how many
+# the generalization performance of our classifier would be to compute how many
 # times our classifier was right and divide it by the number of samples in our
 # set.
 
@@ -160,7 +160,7 @@ _ = plot_confusion_matrix(classifier, data_test, target_test)
 #   people who did not give blood but were predicted to have given blood.
 #
 # Once we have split this information, we can compute metrics to highlight the
-# statistical performance of our classifier in a particular setting. For
+# generalization performance of our classifier in a particular setting. For
 # instance, we could be interested in the fraction of people who really gave
 # blood when the classifier predicted so or the fraction of people predicted to
 # have given blood out of the total population that actually did so.
@@ -269,7 +269,7 @@ np.all(equivalence_pred_proba)
 
 # %% [markdown]
 # The default decision threshold (0.5) might not be the best threshold that
-# leads to optimal statistical performance of our classifier. In this case, one
+# leads to optimal generalization performance of our classifier. In this case, one
 # can vary the decision threshold, and therefore the underlying prediction, and
 # compute the same statistics presented earlier. Usually, the two metrics
 # recall and precision are computed and plotted on a graph. Each metric plotted
@@ -328,8 +328,8 @@ _ = disp.ax_.set_title("ROC AUC curve")
 # This curve was built using the same principle as the precision-recall curve:
 # we vary the probability threshold for determining "hard" prediction and
 # compute the metrics. As with the precision-recall curve, we can compute the
-# area under the ROC (ROC-AUC) to characterize the statistical performance of
+# area under the ROC (ROC-AUC) to characterize the generalization performance of
 # our classifier. However, it is important to observe that the lower bound of
-# the ROC-AUC is 0.5. Indeed, we show the statistical performance of a dummy
-# classifier (the orange dashed line) to show that even the worst statistical
+# the ROC-AUC is 0.5. Indeed, we show the generalization performance of a dummy
+# classifier (the orange dashed line) to show that even the worst generalization
 # performance obtained will be above this line.

--- a/python_scripts/metrics_ex_02.py
+++ b/python_scripts/metrics_ex_02.py
@@ -29,7 +29,7 @@ target /= 1000
 # Write your code here.
 
 # %% [markdown]
-# Then, use the `cross_val_score` to estimate the statistical performance of
+# Then, use the `cross_val_score` to estimate the generalization performance of
 # the model. Use a `KFold` cross-validation with 10 folds. Make the use of the
 # $R^2$ score explicit by assigning the parameter `scoring` (even though it is
 # the default score).

--- a/python_scripts/metrics_regression.py
+++ b/python_scripts/metrics_regression.py
@@ -4,7 +4,7 @@
 # In this notebook, we will present the metrics that can be used in regression.
 #
 # A set of metrics are dedicated to regression. Indeed, classification metrics
-# cannot be used to evaluate the statistical performance of regression models
+# cannot be used to evaluate the generalization performance of regression models
 # because there is a fundamental difference between their target type `target`:
 # it is a continuous variable in regression, while a discrete variable in
 # classification.

--- a/python_scripts/metrics_sol_02.py
+++ b/python_scripts/metrics_sol_02.py
@@ -32,7 +32,7 @@ from sklearn.linear_model import LinearRegression
 model = LinearRegression()
 
 # %% [markdown]
-# Then, use the `cross_val_score` to estimate the statistical performance of
+# Then, use the `cross_val_score` to estimate the generalization performance of
 # the model. Use a `KFold` cross-validation with 10 folds. Make the use of the
 # $R^2$ score explicit by assigning the parameter `scoring` (even though it is
 # the default score).

--- a/python_scripts/parameter_tuning_ex_02.py
+++ b/python_scripts/parameter_tuning_ex_02.py
@@ -16,7 +16,7 @@
 # # 📝 Exercise M3.01
 #
 # The goal is to write an exhaustive search to find the best parameters
-# combination maximizing the model statistical performance.
+# combination maximizing the model generalization performance.
 #
 # Here we use a small subset of the Adult Census dataset to make the code
 # faster to execute. Once your code works on the small subset, try to

--- a/python_scripts/parameter_tuning_ex_03.py
+++ b/python_scripts/parameter_tuning_ex_03.py
@@ -18,7 +18,7 @@
 # # 📝 Exercise M3.02
 #
 # The goal is to find the best set of hyperparameters which maximize the
-# statistical performance on a training set.
+# generalization performance on a training set.
 #
 # Here again with limit the size of the training set to make computation
 # run faster. Feel free to increase the `train_size` value if your computer

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -2,7 +2,7 @@
 # # Hyperparameter tuning by grid-search
 #
 # In the previous notebook, we saw that hyperparameters can affect the
-# statistical performance of a model. In this notebook, we will show how to
+# generalization performance of a model. In this notebook, we will show how to
 # optimize hyperparameters using a grid-search approach.
 
 # %% [markdown]
@@ -235,7 +235,7 @@ ax.invert_yaxis()
 # %% [markdown]
 # The above tables highlights the following things:
 #
-# * for too high values of `learning_rate`, the statistical performance of the
+# * for too high values of `learning_rate`, the generalization performance of the
 #   model is degraded and adjusting the value of `max_leaf_nodes` cannot fix
 #   that problem;
 # * outside of this pathological region, we observe that the optimal choice

--- a/python_scripts/parameter_tuning_manual.py
+++ b/python_scripts/parameter_tuning_manual.py
@@ -49,7 +49,7 @@ model = Pipeline(steps=[
 ])
 
 # %% [markdown]
-# We can evaluate the statistical performance of the model via
+# We can evaluate the generalization performance of the model via
 # cross-validation.
 
 # %%

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -2,7 +2,7 @@
 # # Hyperparameter tuning by randomized-search
 #
 # In the previous notebook, we showed how to use a grid-search approach to
-# search for the best hyperparameters maximizing the statistical performance
+# search for the best hyperparameters maximizing the generalization performance
 # of a predictive model.
 #
 # However, a grid-search approach has limitations. It does not scale when

--- a/python_scripts/parameter_tuning_sol_02.py
+++ b/python_scripts/parameter_tuning_sol_02.py
@@ -16,7 +16,7 @@
 # # 📃 Solution for Exercise M3.01
 #
 # The goal is to write an exhaustive search to find the best parameters
-# combination maximizing the model statistical performance.
+# combination maximizing the model generalization performance.
 #
 # Here we use a small subset of the Adult Census dataset to make the code
 # faster to execute. Once your code works on the small subset, try to

--- a/python_scripts/parameter_tuning_sol_03.py
+++ b/python_scripts/parameter_tuning_sol_03.py
@@ -16,7 +16,7 @@
 # # 📃 Solution for Exercise M3.02
 #
 # The goal is to find the best set of hyperparameters which maximize the
-# statistical performance on a training set.
+# generalization performance on a training set.
 #
 # Here again with limit the size of the training set to make computation
 # run faster. Feel free to increase the `train_size` value if your computer

--- a/python_scripts/trees_hyperparameters.py
+++ b/python_scripts/trees_hyperparameters.py
@@ -180,7 +180,7 @@ _ = plt.title(f"Optimal depth found via CV: "
 # The `max_depth` hyperparameter controls the overall complexity of the tree.
 # This parameter is adequate under the assumption that a tree is built is
 # symmetric. However, there is no guarantee that a tree will be symmetric.
-# Indeed, optimal statistical performance could be reached by growing some of
+# Indeed, optimal generalization performance could be reached by growing some of
 # the branches deeper than some others.
 #
 # We will built a dataset where we will illustrate this asymmetry. We will


### PR DESCRIPTION
Fix #322 (Use generalization performance rather than statistical performance)

Special care was taken for [02_numerical_pipeline_introduction.py](https://github.com/INRIA/scikit-learn-mooc/blob/master/python_scripts/02_numerical_pipeline_introduction.py) to keep self-consistency.