### PR TITLE
Replace predictor, regressor, classifier

### DIFF
--- a/jupyter-book/appendix/glossary.md
+++ b/jupyter-book/appendix/glossary.md
@@ -56,7 +56,7 @@ A model used for [classification](#classification). These models handle
 [targets](#target-label-annotation) that contains discrete values such as
 `0`/`1` or `cat`/`dog`. For example in scikit-learn `LogisticRegression` or
 `HistGradientBoostingClassifier` are classification model
-[classes](#target-label-annotation).
+classes
 
 Note: for historic reasons the `LogisticRegression` name is confusing.
 `LogisticRegression` is not a regression model but a classification model, in

--- a/jupyter-book/appendix/glossary.md
+++ b/jupyter-book/appendix/glossary.md
@@ -46,21 +46,26 @@ is thus the black dotted line. This decision rule is used to
 the line: a [sample](#sample-instance-observation) lying on the left of the
 line will be predicted as a blue sample while a sample lying on the right of
 the line will be predicted as an orange sample. Here, we have a linear
-[classifier](#classifier) because the decision rule is defined as a line (in
+[classification model](#classification-model) because the decision rule is defined as a line (in
 higher dimensions this would be an hyperplane). However, the shape of the
 decision rule will depend on the [model](#model) used.
 
-### classifier
+### classification model
 
 A model used for [classification](#classification). These models handle
 [targets](#target-label-annotation) that contains discrete values such as
 `0`/`1` or `cat`/`dog`. For example in scikit-learn `LogisticRegression` or
-`HistGradientBoostingClassifier` are classifier
+`HistGradientBoostingClassifier` are classification model
 [classes](#target-label-annotation).
 
 Note: for historic reasons the `LogisticRegression` name is confusing.
 `LogisticRegression` is not a regression model but a classification model, in
 contrary with what the name would suggest.
+
+### classifier
+
+The term "classifier" refers to an algorithm for implementing a 
+[classification model](#classification-model). 
 
 ### cross-validation
 
@@ -192,11 +197,11 @@ than the relevant patterns. You can tell a [model](#model) is overfitting when
 it performs great on your [train set](#train-set), but poorly on your [test
 set](#test-set) (or new real-world data).
 
-### predictor
+### predictive model
 
 An [estimator](#estimator) (object with a `fit` method) with a `predict` and/or
-`fit_predict` method. Note a [classifier](#classifier) or a
-[regressor](#regressor) is a predictor. Example of predictor classes are
+`fit_predict` method. Note a [classification model](#classification-model) or a
+[regression model](#regression-model) is a predictive model. Example of predictive model classes are
 `KNeighborsClassifier` and `DecisionTreeRegressor`.
 
 ### predict, prediction
@@ -238,12 +243,19 @@ orange line. To [predict](#predict-prediction) the
 [model](#model) will output the corresponding `y` value lying on the orange
 line.
 
-### regressor
+### regression model
 
-A regressor is a [predictor](#predictor) in a [regression](#regression)
+A regression model is a [predictive model](#predictive-model) in a [regression](#regression)
 setting.
 
-In scikit-learn, `DecisionTreeRegressor` or `Ridge` are regressor classes.
+In scikit-learn, `DecisionTreeRegressor` and `Ridge` are regression model classes.
+
+### regressor
+
+The term "regressor" is quite often used to mean a scikit-learn object implementing 
+a [regression model](#regression-model). 
+
+Note: "regressors" can also mean features used in a regression.
 
 ### regularization, penalization
 

--- a/python_scripts/02_numerical_pipeline_ex_01.py
+++ b/python_scripts/02_numerical_pipeline_ex_01.py
@@ -16,7 +16,7 @@
 # # 📝 Exercise M1.03
 #
 # The goal of this exercise is to compare the generalization performance of our
-# classifier (81% accuracy) to some baseline classifiers that would ignore the
+# classification model (81% accuracy) to some baseline classification models that would ignore the
 # input data and instead make constant predictions.
 #
 # - What would be the score of a model that always predicts `' >50K'`?
@@ -63,7 +63,7 @@ from sklearn.model_selection import train_test_split
 
 
 # %% [markdown]
-# Use a `DummyClassifier` such that the resulting classifier will always
+# Use a `DummyClassifier` such that the resulting classification model will always
 # predict the class `' >50K'`. What is the accuracy score on the test set?
 # Repeat the experiment by always predicting the class `' <=50K'`.
 #

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -106,12 +106,12 @@ model.fit(data, target)
 # %% [markdown]
 # Learning can be represented as follows:
 #
-# ![Predictor fit diagram](../figures/api_diagram-predictor.fit.svg)
+# ![Predictive model fit diagram](../figures/api_diagram-predictor.fit.svg)
 #
 # The method `fit` is composed of two elements: (i) a **learning algorithm**
 # and (ii) some **model states**. The learning algorithm takes the training
 # data and training target as input and sets the model states. These model
-# states will be used later to either predict (for classifiers and regressors)
+# states will be used later to either predict (for classification and regression models)
 # or transform data (for transformers).
 #
 # Both the learning algorithm and the type of model states are specific to each
@@ -133,7 +133,7 @@ target_predicted = model.predict(data)
 # %% [markdown]
 # We can illustrate the prediction mechanism as follows:
 #
-# ![Predictor predict diagram](../figures/api_diagram-predictor.predict.svg)
+# ![Predictive model predict diagram](../figures/api_diagram-predictor.predict.svg)
 #
 # To predict, a model uses a **prediction function** that will use the input
 # data together with the model states. As for the learning algorithm and the
@@ -211,7 +211,7 @@ print(f"The testing dataset contains {data_test.shape[0]} samples and "
 # %% [markdown]
 #
 # Instead of computing the prediction and manually computing the average
-# success rate, we can use the method `score`. When dealing with classifiers
+# success rate, we can use the method `score`. When dealing with classification models
 # this method returns their performance metric.
 
 # %%
@@ -224,9 +224,9 @@ print(f"The test accuracy using a {model_name} is "
 # %% [markdown]
 # Let's check the underlying mechanism when the `score` method is called:
 #
-# ![Predictor score diagram](../figures/api_diagram-predictor.score.svg)
+# ![Predictive model score diagram](../figures/api_diagram-predictor.score.svg)
 #
-# To compute the score, the predictor first computes the predictions (using
+# To compute the score, the predictive model first computes the predictions (using
 # the `predict` method) and then uses a scoring function to compare the
 # true target `y` and the predictions. Finally, the score is returned.
 

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -120,7 +120,7 @@ scaler.fit(data_train)
 
 # %% [markdown]
 # The `fit` method for transformers is similar to the `fit` method for
-# predictors. The main difference is that the former has a single argument (the
+# predictive models. The main difference is that the former has a single argument (the
 # data matrix), whereas the latter has two arguments (the data matrix and the
 # target).
 #
@@ -166,12 +166,12 @@ data_train_scaled
 
 # %% [markdown]
 # Let's illustrate the internal mechanism of the `transform` method and put it
-# to perspective with what we already saw with predictors.
+# to perspective with what we already saw with predictive models.
 #
 # ![Transformer transform diagram](../figures/api_diagram-transformer.transform.svg)
 #
 # The `transform` method for transformers is similar to the `predict` method
-# for predictors. It uses a predefined function, called a **transformation
+# for predictive models. It uses a predefined function, called a **transformation
 # function**, and uses the model states and the input data. However, instead of
 # outputting predictions, the job of the `transform` method is to output a
 # transformed version of the input data.
@@ -194,9 +194,9 @@ data_train_scaled.describe()
 # %% [markdown]
 # We can easily combine these sequential operations with a scikit-learn
 # `Pipeline`, which chains together operations and is used as any other
-# classifier or regressor. The helper function `make_pipeline` will create a
+# classification or regression model. The helper function `make_pipeline` will create a
 # `Pipeline`: it takes as arguments the successive transformations to perform,
-# followed by the classifier or regressor model.
+# followed by the classification or regression model.
 
 # %%
 import time
@@ -216,7 +216,7 @@ model
 model.named_steps
 
 # %% [markdown]
-# This predictive pipeline exposes the same methods as the final predictor:
+# This predictive pipeline exposes the same methods as the final predictive model:
 # `fit` and `predict` (and additionally `predict_proba`, `decision_function`,
 # or `score`).
 
@@ -236,7 +236,7 @@ elapsed_time = time.time() - start
 #
 # - learn their internal model states
 # - transform the training data. Finally, the preprocessed data are provided to
-#   train the predictor.
+#   train the predictive model.
 #
 # To predict the targets given a test set, one uses the `predict` method.
 
@@ -253,7 +253,7 @@ predicted_target[:5]
 # called to preprocess the data. Note that there is no need to call the `fit`
 # method for these transformers because we are using the internal model states
 # computed when calling `model.fit`. The preprocessed data is then provided to
-# the predictor that will output the predicted target by calling its method
+# the predictive model that will output the predicted target by calling its method
 # `predict`.
 #
 # As a shorthand, we can check the score of the full predictive pipeline
@@ -294,7 +294,7 @@ print(f"The accuracy using a {model_name} is {score:.3f} "
 # Working with non-scaled data will potentially force the algorithm to iterate
 # more as we showed in the example above. There is also the catastrophic
 # scenario where the number of required iterations are more than the maximum
-# number of iterations allowed by the predictor (controlled by the `max_iter`)
+# number of iterations allowed by the predictive model (controlled by the `max_iter`)
 # parameter. Therefore, before increasing `max_iter`, make sure that the data
 # are well scaled.
 # ```

--- a/python_scripts/02_numerical_pipeline_sol_01.py
+++ b/python_scripts/02_numerical_pipeline_sol_01.py
@@ -15,9 +15,9 @@
 # %% [markdown]
 # # 📃 Solution for Exercise M1.03
 #
-# The goal of this exercise is to compare the performance of our classifier in
+# The goal of this exercise is to compare the performance of our classification model in
 # the previous notebook (roughly 81% accuracy with `LogisticRegression`) to
-# some simple baseline classifiers. The simplest baseline classifier is one
+# some simple baseline classification models. The simplest baseline classification model is one
 # that always predicts the same class, irrespective of the input data.
 #
 # - What would be the score of a model that always predicts `' >50K'`?
@@ -64,7 +64,7 @@ data_numeric_train, data_numeric_test, target_train, target_test = \
     train_test_split(data_numeric, target, random_state=42)
 
 # %% [markdown]
-# We will first create a dummy classifier which will always predict the
+# We will first create a dummy classification model which will always predict the
 # high revenue class, i.e. `" >50K"`, and check the generalization
 # performance.
 
@@ -96,7 +96,7 @@ print(f"Accuracy of a model predicting only low revenue: {score:.3f}")
 # the fact that we have 3/4 of the target belonging to low-revenue class.
 
 # %% [markdown]
-# Therefore, any predictive model giving results below this dummy classifier
+# Therefore, any predictive model giving results below this dummy classification model
 # will not be helpful.
 
 # %%

--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -274,7 +274,7 @@ pd.DataFrame(data_encoded, columns=columns_encoded).head()
 # ## Evaluate our predictive pipeline
 #
 # We can now integrate this encoder inside a machine learning pipeline like we
-# did with numerical data: let's train a linear classifier on the encoded data
+# did with numerical data: let's train a linear classification model on the encoded data
 # and check the generalization performance of this machine learning pipeline using
 # cross-validation.
 #
@@ -287,7 +287,7 @@ data["native-country"].value_counts()
 # %% [markdown]
 # We see that the `Holand-Netherlands` category is occurring rarely. This will
 # be a problem during cross-validation: if the sample ends up in the test set
-# during splitting then the classifier would not have seen the category during
+# during splitting then the classification model would not have seen the category during
 # training and will not be able to encode it.
 #
 # In scikit-learn, there are two solutions to bypass this issue:

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -117,8 +117,8 @@ preprocessor = ColumnTransformer([
 # * It then **concatenates the transformed datasets** into a single dataset.
 
 # The important thing is that `ColumnTransformer` is like any other
-# scikit-learn transformer. In particular it can be combined with a classifier
-# in a `Pipeline`:
+# scikit-learn transformer. In particular it can be combined with a classification
+# model in a `Pipeline`:
 
 # %%
 from sklearn.linear_model import LogisticRegression
@@ -139,7 +139,7 @@ model
 # the same API (the same set of methods that can be called by the user):
 #
 # - the `fit` method is called to preprocess the data and then train the
-#   classifier of the preprocessed data;
+#   classification model of the preprocessed data;
 # - the `predict` method makes predictions on new data;
 # - the `score` method is used to predict on the test data and compare the
 #   predictions to the expected test labels to compute the accuracy.
@@ -192,7 +192,7 @@ model.score(data_test, target_test)
 #
 # As previously stated, a predictive model should be evaluated by
 # cross-validation. Our model is usable with the cross-validation tools of
-# scikit-learn as any other predictors:
+# scikit-learn just as any other predictive model:
 
 # %%
 from sklearn.model_selection import cross_validate

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -53,7 +53,7 @@ data_categorical = data[categorical_columns]
 
 # %% [markdown]
 # Define a scikit-learn pipeline composed of an `OrdinalEncoder` and a
-# `LogisticRegression` classifier.
+# `LogisticRegression` classification model.
 #
 # Because `OrdinalEncoder` can raise errors if it sees an unknown category at
 # prediction time, you can set the `handle_unknown="use_encoded_value"` and

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -16,7 +16,7 @@
 # # 📝 Exercise M1.05
 #
 # The goal of this exercise is to evaluate the impact of feature preprocessing
-# on a pipeline that uses a decision-tree-based classifier instead of a logistic
+# on a pipeline that uses a decision-tree-based classification model instead of a logistic
 # regression.
 #
 # - The first question is to empirically evaluate whether scaling numerical

--- a/python_scripts/03_categorical_pipeline_sol_01.py
+++ b/python_scripts/03_categorical_pipeline_sol_01.py
@@ -121,7 +121,7 @@ print("The mean cross-validation accuracy is: "
       f"{scores.mean():.3f} +/- {scores.std():.3f}")
 
 # %% [markdown]
-# With the linear classifier chosen, using an encoding that does not assume
+# With the linear classification model chosen, using an encoding that does not assume
 # any ordering lead to much better result.
 #
 # The important message here is: linear model and `OrdinalEncoder` are used

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -16,7 +16,7 @@
 # # 📃 Solution for Exercise M1.05
 #
 # The goal of this exercise is to evaluate the impact of feature preprocessing
-# on a pipeline that uses a decision-tree-based classifier instead of logistic
+# on a pipeline that uses a decision-tree-based classification model instead of logistic
 # regression.
 #
 # - The first question is to empirically evaluate whether scaling numerical

--- a/python_scripts/cross_validation_baseline.py
+++ b/python_scripts/cross_validation_baseline.py
@@ -36,7 +36,7 @@ cv = ShuffleSplit(n_splits=30, test_size=0.2, random_state=0)
 
 # %% [markdown]
 # We will start by running the cross-validation for the decision tree
-# regressor which is our model of interest. Besides, we will store the
+# regression which is our model of interest. Besides, we will store the
 # testing error in a pandas series.
 
 # %%
@@ -54,8 +54,8 @@ errors_regressor = pd.Series(-result_regressor["test_score"],
 
 # %% [markdown]
 # Then, we will evaluate our first baseline. This baseline is called a dummy
-# regressor. This dummy regressor will always predict the mean target computed
-# on the training. Therefore, the dummy regressor will never use any
+# regression model. It will always predict the mean target computed
+# on the training set. Therefore, the dummy regression model will never use any
 # information regarding the data `data`.
 
 # %%
@@ -84,7 +84,7 @@ errors_permutation = pd.Series(-permutation_score, name="Permuted error")
 
 # %% [markdown]
 # Finally, we plot the testing errors for the two baselines and the
-# actual regressor.
+# actual regression model.
 
 # %%
 final_errors = pd.concat([errors_regressor, errors_dummy, errors_permutation],
@@ -101,9 +101,9 @@ _ = plt.title("Distribution of the testing errors")
 # %% [markdown]
 # We see that even if the generalization performance of our model is far from
 # being good, it is better than the two baselines. Besides, we see that the
-# dummy regressor is better than a chance level regressor.
+# dummy regression model is better than a chance level regression model.
 #
-# In practice, using a dummy regressor might be sufficient as a baseline.
+# In practice, using a dummy regression model might be sufficient as a baseline.
 # Indeed, to obtain a reliable estimate the permutation of the target should
 # be repeated and thus this method is costly. However, it gives the true
 # chance level.

--- a/python_scripts/cross_validation_ex_01.py
+++ b/python_scripts/cross_validation_ex_01.py
@@ -3,12 +3,12 @@
 #
 # The aim of this exercise is to make the following experiments:
 #
-# * train and test a support vector machine classifier through
+# * train and test a support vector machine classification model through
 #   cross-validation;
-# * study the effect of the parameter gamma of this classifier using a
+# * study the effect of the parameter gamma of this classification model using a
 #   validation curve;
 # * use a learning curve to determine the usefulness of adding new
-#   samples in the dataset when building a classifier.
+#   samples in the dataset when building a classification model.
 #
 # To make these experiments we will first load the blood transfusion dataset.
 
@@ -26,13 +26,13 @@ data = blood_transfusion.drop(columns="Class")
 target = blood_transfusion["Class"]
 
 # %% [markdown]
-# We will use a support vector machine classifier (SVM). In its most simple
-# form, a SVM classifier is a linear classifier behaving similarly to a
+# We will use a support vector machine classification model (SVM). In its most simple
+# form, a SVM is a linear classification model behaving similarly to a
 # logistic regression. Indeed, the optimization used to find the optimal
 # weights of the linear model are different but we don't need to know these
 # details for the exercise.
 #
-# Also, this classifier can become more flexible/expressive by using a
+# Also, this classification model can become more flexible/expressive by using a
 # so-called kernel that makes the model become non-linear. Again, no requirement
 # regarding the mathematics is required to accomplish this exercise.
 #

--- a/python_scripts/cross_validation_ex_02.py
+++ b/python_scripts/cross_validation_ex_02.py
@@ -1,7 +1,7 @@
 # %% [markdown]
 # # 📝 Exercise M7.01
 #
-# This notebook aims at building baseline classifiers, which we'll use to
+# This notebook aims at building baseline classification models, which we'll use to
 # compare our predictive model. Besides, we will check the differences with
 # the baselines that we saw in regression.
 #
@@ -42,7 +42,7 @@ data, target = adult_census.drop(columns="class"), adult_census["class"]
 # Write your code here.
 
 # %% [markdown]
-# Finally, compute the test score of a dummy classifier which would predict
+# Finally, compute the test score of a dummy classification model which would predict
 # the most frequent class from the training set. You can look at the
 # `sklearn.dummy.DummyClassifier` class.
 
@@ -66,7 +66,7 @@ data, target = adult_census.drop(columns="class"), adult_census["class"]
 # Write your code here.
 
 # %% [markdown]
-# Change the strategy of the dummy classifier to `stratified`, compute the
+# Change the strategy of the dummy classification model to `stratified`, compute the
 # results and plot the distribution together with the other results. Explain
 # why the results get worse.
 

--- a/python_scripts/cross_validation_ex_03.py
+++ b/python_scripts/cross_validation_ex_03.py
@@ -12,7 +12,7 @@ from sklearn.datasets import load_iris
 data, target = load_iris(return_X_y=True, as_frame=True)
 
 # %% [markdown]
-# Create a decision tree classifier that we will use in the next experiments.
+# Create a decision tree classification model that we will use in the next experiments.
 
 # %%
 # Write your code here.
@@ -20,7 +20,7 @@ data, target = load_iris(return_X_y=True, as_frame=True)
 # %% [markdown]
 # As a first experiment, use the utility
 # `sklearn.model_selection.train_test_split` to split the data into a train
-# and test set. Train the classifier using the train set and check the score
+# and test set. Train the classification model using the train set and check the score
 # on the test set.
 
 # %%

--- a/python_scripts/cross_validation_ex_04.py
+++ b/python_scripts/cross_validation_ex_04.py
@@ -13,7 +13,7 @@ data, target = load_digits(return_X_y=True, as_frame=True)
 
 # %% [markdown]
 # The first step is to create a model. Use a machine learning pipeline
-# composed of a scaler followed by a logistic regression classifier.
+# composed of a scaler followed by a logistic regression classification model.
 
 # %%
 # Write your code here.

--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -12,7 +12,7 @@ data, target = digits.data, digits.target
 
 # %% [markdown]
 # We will recreate the same model used in the previous exercise:
-# a logistic regression classifier with preprocessor to scale the data.
+# a logistic regression classification model with preprocessor to scale the data.
 
 # %%
 from sklearn.preprocessing import StandardScaler

--- a/python_scripts/cross_validation_nested.py
+++ b/python_scripts/cross_validation_nested.py
@@ -7,7 +7,7 @@
 #
 # Cross-validation is a powerful tool to evaluate the generalization performance
 # of a model. It is also used to select the best model from a pool of models.
-# This pool of models can be the same family of predictor but with different
+# This pool of models can be the same family of predictive models but with different
 # parameters. In this case, we call this procedure **hyperparameter tuning**.
 #
 # We could also imagine that we would like to choose among heterogeneous models

--- a/python_scripts/cross_validation_sol_01.py
+++ b/python_scripts/cross_validation_sol_01.py
@@ -5,12 +5,12 @@
 #
 # The aim of this exercise is to make the following experiments:
 #
-# * train and test a support vector machine classifier through
+# * train and test a support vector machine classification model through
 #   cross-validation;
-# * study the effect of the parameter gamma of this classifier using a
+# * study the effect of the parameter gamma of this classification model using a
 #   validation curve;
 # * use a learning curve to determine the usefulness of adding new
-#   samples in the dataset when building a classifier.
+#   samples in the dataset when building a classification model.
 #
 # To make these experiments we will first load the blood transfusion dataset.
 
@@ -28,13 +28,13 @@ data = blood_transfusion.drop(columns="Class")
 target = blood_transfusion["Class"]
 
 # %% [markdown]
-# We will use a support vector machine classifier (SVM). In its most simple
-# form, a SVM classifier is a linear classifier behaving similarly to a
+# We will use a support vector machine classification model (SVM). In its most simple
+# form, a SVM is a linear classification model behaving similarly to a
 # logistic regression. Indeed, the optimization used to find the optimal
 # weights of the linear model are different but we don't need to know these
 # details for the exercise.
 #
-# Also, this classifier can become more flexible/expressive by using a
+# Also, this classification model can become more flexible/expressive by using a
 # so-called kernel that makes the model become non-linear. Again, no requirement
 # regarding the mathematics is required to accomplish this exercise.
 #
@@ -125,9 +125,9 @@ _ = plt.title("Validation score of support vector machine")
 
 # %% [markdown]
 # Looking at the curve, we can clearly identify the over-fitting regime of
-# the SVC classifier when `gamma > 1`.
+# the SVC classification model when `gamma > 1`.
 # The best setting is around `gamma = 1` while for `gamma < 1`,
-# it is not very clear if the classifier is under-fitting but the
+# it is not very clear if the classification model is under-fitting but the
 # testing score is worse than for `gamma = 1`.
 
 # %% [markdown]

--- a/python_scripts/cross_validation_sol_02.py
+++ b/python_scripts/cross_validation_sol_02.py
@@ -1,7 +1,7 @@
 # %% [markdown]
 # # 📃 Solution for Exercise M7.01
 #
-# This notebook aims at building baseline classifiers, which we'll use to
+# This notebook aims at building baseline classification models, which we'll use to
 # compare our predictive model. Besides, we will check the differences with
 # the baselines that we saw in regression.
 #
@@ -57,7 +57,7 @@ score, permutation_score, pvalue = permutation_test_score(
 test_score_permutation = pd.Series(permutation_score, name="Permuted score")
 
 # %% [markdown]
-# Finally, compute the test score of a dummy classifier which would predict
+# Finally, compute the test score of a dummy classification model which would predict
 # the most frequent class from the training set. You can look at the
 # `sklearn.dummy.DummyClassifier` class.
 
@@ -93,12 +93,12 @@ plt.xlabel("Accuracy (%)")
 _ = plt.title("Distribution of the test scores")
 
 # %% [markdown]
-# We observe that the dummy classifier with the strategy `most_frequent` is
+# We observe that the dummy classification model with the strategy `most_frequent` is
 # equivalent to the permutation score. We can also conclude that our model
 # is better than the other baseline.
 
 # %% [markdown]
-# Change the strategy of the dummy classifier to `stratified`, compute the
+# Change the strategy of the dummy classification model to `stratified`, compute the
 # results and plot the distribution together with the other results. Explain
 # why the results get worse.
 

--- a/python_scripts/cross_validation_time.py
+++ b/python_scripts/cross_validation_time.py
@@ -54,7 +54,7 @@ data_train, data_test, target_train, target_test = train_test_split(
     data, target, shuffle=True, random_state=0)
 
 # %% [markdown]
-# We will use a decision tree regressor that we expect to overfit and thus not
+# We will use a decision tree regression model that we expect to overfit and thus not
 # generalize to unseen data. We will use a `ShuffleSplit` cross-validation to
 # check the generalization performance of our model.
 #

--- a/python_scripts/cross_validation_train_test.py
+++ b/python_scripts/cross_validation_train_test.py
@@ -53,7 +53,7 @@ target.head()
 # %% [markdown]
 # ## Training error vs testing error
 #
-# To solve this regression task, we will use a decision tree regressor.
+# To solve this regression task, we will use a decision tree regression model.
 
 # %%
 from sklearn.tree import DecisionTreeRegressor
@@ -62,7 +62,7 @@ regressor = DecisionTreeRegressor(random_state=0)
 regressor.fit(data, target)
 
 # %% [markdown]
-# After training the regressor, we would like to know its potential generalization
+# After training the regression model, we would like to know its potential generalization
 # performance once deployed in production. For this purpose, we use the mean
 # absolute error, which gives us an error in the native unit, i.e. k\$.
 
@@ -71,7 +71,7 @@ from sklearn.metrics import mean_absolute_error
 
 target_predicted = regressor.predict(data)
 score = mean_absolute_error(target, target_predicted)
-print(f"On average, our regressor makes an error of {score:.2f} k$")
+print(f"On average, our regression model makes an error of {score:.2f} k$")
 
 # %% [markdown]
 # We get perfect prediction with no error. It is too optimistic and almost
@@ -172,7 +172,7 @@ print(f"The testing error of our model is {score:.2f} k$")
 # will train 40 models in total and all of them will be discarded: we just
 # record their generalization performance on each variant of the test set.
 #
-# To evaluate the generalization performance of our regressor, we can use
+# To evaluate the generalization performance of our regression model, we can use
 # [`sklearn.model_selection.cross_validate`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html)
 # with a
 # [`sklearn.model_selection.ShuffleSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ShuffleSplit.html)
@@ -319,10 +319,9 @@ cv_results
 cv_results["estimator"]
 
 # %% [markdown]
-# The five decision tree regressors corresponds to the five fitted decision
-# trees on the different folds. Having access to these regressors is handy
-# because it allows to inspect the internal fitted parameters of these
-# regressors.
+# The five decision tree regression models correspond to the five fitted decision
+# trees on the different folds. Having access to these regression models is handy
+# because it allows to inspect the internal fitted parameters of such models.
 #
 # In the case where you only are interested in the test score, scikit-learn
 # provide a `cross_val_score` function. It is identical to calling the

--- a/python_scripts/datasets_blood_transfusion.py
+++ b/python_scripts/datasets_blood_transfusion.py
@@ -87,7 +87,7 @@ target.value_counts(normalize=True)
 
 # %% [markdown]
 # Indeed, ~76% of the samples belong to the class `"not donated"`. It is rather
-# important: a classifier that would predict always this `"not donated"` class
+# important: a classification model that would predict always this `"not donated"` class
 # would achieve an accuracy of 76% of good classification without using any
 # information from the data itself. This issue is known as class imbalance. One
 # should take care about the generalization performance metric used to evaluate a

--- a/python_scripts/ensemble_adaboost.py
+++ b/python_scripts/ensemble_adaboost.py
@@ -97,16 +97,16 @@ _ = plt.title("Decision tree predictions \nwith misclassified samples "
               "highlighted")
 
 # %% [markdown]
-# We observe that several samples have been misclassified by the classifier.
+# We observe that several samples have been misclassified by the classification model.
 #
-# We mentioned that boosting relies on creating a new classifier which tries to
+# We mentioned that boosting relies on creating a new classification model which tries to
 # correct these misclassifications. In scikit-learn, learners have a
 # parameter `sample_weight` which forces it to pay more attention to
 # samples with higher weights during the training.
 #
 # This parameter is set when calling
 # `classifier.fit(X, y, sample_weight=weights)`.
-# We will use this trick to create a new classifier by 'discarding' all
+# We will use this trick to create a new classification model by 'discarding' all
 # correctly classified samples and only considering the misclassified samples.
 # Thus, misclassified samples will be assigned a weight of 1 and well
 # classified samples will be assigned a weight of 0.
@@ -146,8 +146,8 @@ print(f"Number of samples previously misclassified and "
 
 # %% [markdown]
 # However, we are making mistakes on previously well classified samples. Thus,
-# we get the intuition that we should weight the predictions of each classifier
-# differently, most probably by using the number of mistakes each classifier
+# we get the intuition that we should weight the predictions of each classification model
+# differently, most probably by using the number of mistakes each classification model
 # is making.
 #
 # So we could use the classification error to combine both trees.
@@ -160,12 +160,12 @@ ensemble_weight = [
 ensemble_weight
 
 # %% [markdown]
-# The first classifier was 94% accurate and the second one 69% accurate.
-# Therefore, when predicting a class, we should trust the first classifier
+# The first classification model was 94% accurate and the second one 69% accurate.
+# Therefore, when predicting a class, we should trust the first model
 # slightly more than the second one. We could use these accuracy values to
 # weight the predictions of each learner.
 #
-# To summarize, boosting learns several classifiers, each of which will
+# To summarize, boosting learns several classification models, each of which will
 # focus more or less on specific samples of the dataset. Boosting is thus
 # different from bagging: here we never resample our dataset, we just assign
 # different weights to the original dataset.
@@ -180,8 +180,8 @@ ensemble_weight
 # learner weights. However, there are statistical theories (like in AdaBoost)
 # for how these sample and learner weights can be optimally calculated.
 #
-# We will use the AdaBoost classifier implemented in scikit-learn and
-# look at the underlying decision tree classifiers trained.
+# We will use the AdaBoost classification model implemented in scikit-learn and
+# look at the underlying decision tree classification models trained.
 
 # %%
 from sklearn.ensemble import AdaBoostClassifier
@@ -203,17 +203,17 @@ for boosting_round, tree in enumerate(adaboost.estimators_):
     _ = plt.title(f"Decision tree trained at round {boosting_round}")
 
 # %%
-print(f"Weight of each classifier: {adaboost.estimator_weights_}")
+print(f"Weight of each classification model: {adaboost.estimator_weights_}")
 
 # %%
-print(f"Error of each classifier: {adaboost.estimator_errors_}")
+print(f"Error of each classification model: {adaboost.estimator_errors_}")
 
 # %% [markdown]
-# We see that AdaBoost learned three different classifiers, each of which
+# We see that AdaBoost learned three different classification models, each of which
 # focuses on different samples. Looking at the weights of each learner, we see
-# that the ensemble gives the highest weight to the first classifier. This
-# indeed makes sense when we look at the errors of each classifier. The first
-# classifier also has the highest classification generalization performance.
+# that the ensemble gives the highest weight to the first model. This
+# indeed makes sense when we look at the errors of each classification model. The first
+# home also has the highest classification generalization performance.
 #
 # While AdaBoost is a nice algorithm to demonstrate the internal machinery of
 # boosting algorithms, it is not the most efficient.

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -210,7 +210,7 @@ _ = plt.title("Predictions of bagged trees")
 # %% [markdown]
 #
 # The unbroken red line shows the averaged predictions, which would be the
-# final predictions given by our 'bag' of decision tree regressors. Note that
+# final predictions given by our 'bag' of decision tree regression models. Note that
 # the predictions of the ensemble is more stable because of the averaging
 # operation. As a result, the bag of trees as a whole is less likely to overfit
 # than the individual trees.
@@ -244,7 +244,7 @@ sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
 bagged_trees_predictions = bagged_trees.predict(data_test)
 plt.plot(data_test, bagged_trees_predictions)
 
-_ = plt.title("Predictions from a bagging classifier")
+_ = plt.title("Predictions from a bagging classification model")
 
 # %% [markdown]
 #

--- a/python_scripts/ensemble_ex_01.py
+++ b/python_scripts/ensemble_ex_01.py
@@ -2,7 +2,7 @@
 # # 📝 Exercise M6.01
 #
 # The aim of this notebook is to investigate if we can tune the hyperparameters
-# of a bagging regressor and evaluate the gain obtained.
+# of a bagging regression model and evaluate the gain obtained.
 #
 # We will load the California housing dataset and split it into a training and
 # a testing set.
@@ -24,7 +24,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 
 # %% [markdown]
 # Create a `BaggingRegressor` and provide a `DecisionTreeRegressor`
-# to its parameter `base_estimator`. Train the regressor and evaluate its
+# to its parameter `base_estimator`. Train the regression model and evaluate its
 # generalization performance on the testing set using the mean absolute error.
 
 # %%
@@ -32,13 +32,13 @@ data_train, data_test, target_train, target_test = train_test_split(
 
 # %% [markdown]
 # Now, create a `RandomizedSearchCV` instance using the previous model and
-# tune the important parameters of the bagging regressor. Find the best
+# tune the important parameters of the bagging regression model. Find the best
 # parameters  and check if you are able to find a set of parameters that
-# improve the default regressor still using the mean absolute error as a
+# improve the default regression model still using the mean absolute error as a
 # metric.
 
 # ```{tip}
-# You can list the bagging regressor's parameters using the `get_params`
+# You can list the bagging regression model's parameters using the `get_params`
 # method.
 # ```
 
@@ -46,5 +46,5 @@ data_train, data_test, target_train, target_test = train_test_split(
 # Write your code here.
 
 # %% [markdown]
-# We see that the bagging regressor provides a predictor in which fine tuning
+# We see that the bagging regression model provides a predictive model in which fine tuning
 # is not as important as in the case of fitting a single decision tree.

--- a/python_scripts/ensemble_ex_03.py
+++ b/python_scripts/ensemble_ex_03.py
@@ -24,7 +24,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 # ```
 
 # %% [markdown]
-# Then, create an `AbaBoostRegressor`. Use the function
+# Then, create an `AdaBoostRegressor`. Use the function
 # `sklearn.model_selection.validation_curve` to get training and test scores
 # by varying the number of estimators. Use the mean absolute error as a metric
 # by passing `scoring="neg_mean_absolute_error"`.
@@ -48,7 +48,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 # the model.
 
 # %% [markdown]
-# Repeat the experiment using a random forest instead of an AdaBoost regressor.
+# Repeat the experiment using a random forest instead of an AdaBoost regression model.
 
 # %%
 # Write your code here.

--- a/python_scripts/ensemble_ex_05.py
+++ b/python_scripts/ensemble_ex_05.py
@@ -15,7 +15,7 @@ data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$
 
 # %% [markdown]
-# First, create a histogram gradient boosting regressor. You can set the
+# First, create a histogram gradient boosting regression model. You can set the
 # trees number to be large, and configure the model to use early-stopping.
 
 # %%

--- a/python_scripts/ensemble_gradient_boosting.py
+++ b/python_scripts/ensemble_gradient_boosting.py
@@ -52,7 +52,7 @@ _ = plt.title("Synthetic regression dataset")
 
 # %% [markdown]
 # As we previously discussed, boosting will be based on assembling a sequence
-# of learners. We will start by creating a decision tree regressor. We will set
+# of learners. We will start by creating a decision tree regression model. We will set
 # the depth of the tree so that the resulting learner will underfit the data.
 
 # %%

--- a/python_scripts/ensemble_hist_gradient_boosting.py
+++ b/python_scripts/ensemble_hist_gradient_boosting.py
@@ -94,7 +94,7 @@ data_trans
 # %% [markdown]
 # After this transformation, we see that we have at most 256 unique values per
 # features. Now, we will use this transformer to discretize data before
-# training the gradient boosting regressor.
+# training the gradient boosting regression model.
 
 # %%
 from sklearn.pipeline import make_pipeline

--- a/python_scripts/ensemble_introduction.py
+++ b/python_scripts/ensemble_introduction.py
@@ -22,7 +22,7 @@ data, target = fetch_california_housing(as_frame=True, return_X_y=True)
 target *= 100  # rescale the target in k$
 
 # %% [markdown]
-# We will check the generalization performance of decision tree regressor with
+# We will check the generalization performance of decision tree regression model with
 # default parameters.
 
 # %%
@@ -83,9 +83,9 @@ print(f"R2 score obtained by cross-validation: "
 #
 # Now we will use an ensemble method called bagging. More details about this
 # method will be discussed in the next section. In short, this method will use
-# a base regressor (i.e. decision tree regressors) and will train several of
+# a base regression (i.e. decision tree regression models) and will train several of
 # them on a slightly modified version of the training set. Then, the
-# predictions of all these base regressors will be combined by averaging.
+# predictions of all these base regressions will be combined by averaging.
 #
 # Here, we will use 20 decision trees and check the fitting time as well as the
 # generalization performance on the left-out testing data. It is important to note
@@ -107,7 +107,7 @@ print(f"R2 score obtained by cross-validation: "
 
 # %% [markdown]
 # Without searching for optimal hyperparameters, the overall generalization
-# performance of the bagging regressor is better than a single decision tree.
+# performance of the bagging regression model is better than a single decision tree.
 # In addition, the computational cost is reduced in comparison of seeking
 # for the optimal hyperparameters.
 #

--- a/python_scripts/ensemble_random_forest.py
+++ b/python_scripts/ensemble_random_forest.py
@@ -5,9 +5,9 @@
 # differences with the bagging ensembles.
 #
 # Random forests are a popular model in machine learning. They are a
-# modification of the bagging algorithm. In bagging, any classifier or
-# regressor can be used. In random forests, the base classifier or regressor
-# is always a decision tree.
+# modification of the bagging algorithm. In bagging, any classification or
+# regression model can be used. In random forests, the base classification or regression
+# model is always a decision tree.
 #
 # Random forests have another particularity: when training a tree, the search
 # for the best split is done only on a subset of the original features taken at
@@ -23,7 +23,7 @@
 #
 # ## A look at random forests
 #
-# We will illustrate the usage of a random forest classifier on the adult
+# We will illustrate the usage of a random forest classification model on the adult
 # census dataset.
 
 # %%
@@ -68,7 +68,7 @@ preprocessor = make_column_transformer(
 # %% [markdown]
 #
 # We will first give a simple example where we will train a single decision
-# tree classifier and check its generalization performance via cross-validation.
+# tree classification model and check its generalization performance via cross-validation.
 
 # %%
 from sklearn.pipeline import make_pipeline
@@ -81,13 +81,13 @@ from sklearn.model_selection import cross_val_score
 
 scores_tree = cross_val_score(tree, data, target)
 
-print(f"Decision tree classifier: "
+print(f"Decision tree classification model: "
       f"{scores_tree.mean():.3f} +/- {scores_tree.std():.3f}")
 
 # %% [markdown]
 #
 # Similarly to what was done in the previous notebook, we construct a
-# `BaggingClassifier` with a decision tree classifier as base model. In
+# `BaggingClassifier` with a decision tree classification model as base model. In
 # addition, we need to specify how many models do we want to combine. Note that
 # we also need to preprocess the data and thus use a scikit-learn pipeline.
 
@@ -105,7 +105,7 @@ bagged_trees = make_pipeline(
 # %%
 scores_bagged_trees = cross_val_score(bagged_trees, data, target)
 
-print(f"Bagged decision tree classifier: "
+print(f"Bagged decision tree classification model: "
       f"{scores_bagged_trees.mean():.3f} +/- {scores_bagged_trees.std():.3f}")
 
 # %% [markdown]
@@ -128,7 +128,7 @@ random_forest = make_pipeline(
 # %%
 scores_random_forest = cross_val_score(random_forest, data, target)
 
-print(f"Random forest classifier: "
+print(f"Random forest classification model: "
       f"{scores_random_forest.mean():.3f} +/- "
       f"{scores_random_forest.std():.3f}")
 

--- a/python_scripts/ensemble_sol_01.py
+++ b/python_scripts/ensemble_sol_01.py
@@ -2,7 +2,7 @@
 # # 📃 Solution of Exercise M6.01
 #
 # The aim of this notebook is to investigate if we can tune the hyperparameters
-# of a bagging regressor and evaluate the gain obtained.
+# of a bagging regression model and evaluate the gain obtained.
 #
 # We will load the California housing dataset and split it into a training and
 # a testing set.
@@ -24,7 +24,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 
 # %% [markdown]
 # Create a `BaggingRegressor` and provide a `DecisionTreeRegressor`
-# to its parameter `base_estimator`. Train the regressor and evaluate its
+# to its parameter `base_estimator`. Train the regression model and evaluate its
 # generalization performance on the testing set using the mean absolute error.
 
 # %%
@@ -36,18 +36,18 @@ tree = DecisionTreeRegressor()
 bagging = BaggingRegressor(base_estimator=tree, n_jobs=2)
 bagging.fit(data_train, target_train)
 target_predicted = bagging.predict(data_test)
-print(f"Basic mean absolute error of the bagging regressor:\n"
+print(f"Basic mean absolute error of the bagging regression model:\n"
       f"{mean_absolute_error(target_test, target_predicted):.2f} k$")
 
 # %% [markdown]
 # Now, create a `RandomizedSearchCV` instance using the previous model and
-# tune the important parameters of the bagging regressor. Find the best
+# tune the important parameters of the bagging regression model. Find the best
 # parameters  and check if you are able to find a set of parameters that
-# improve the default regressor still using the mean absolute error as a
+# improve the default regression model still using the mean absolute error as a
 # metric.
 
 # ```{tip}
-# You can list the bagging regressor's parameters using the `get_params`
+# You can list the bagging regression model's parameters using the `get_params`
 # method.
 # ```
 
@@ -82,12 +82,12 @@ cv_results
 
 # %%
 target_predicted = search.predict(data_test)
-print(f"Mean absolute error after tuning of the bagging regressor:\n"
+print(f"Mean absolute error after tuning of the bagging regression model:\n"
       f"{mean_absolute_error(target_test, target_predicted):.2f} k$")
 
 # %% [markdown]
-# We see that the predictor provided by the bagging regressor does not need
+# We see that the predictive model provided by the bagging regression model does not need
 # much hyperparameter tuning compared to a single decision tree. We see that
-# the bagging regressor provides a predictor for which tuning the
+# the bagging regression model provides a predictive model for which tuning the
 # hyperparameters is not as important as in the case of fitting a single
 # decision tree.

--- a/python_scripts/ensemble_sol_03.py
+++ b/python_scripts/ensemble_sol_03.py
@@ -61,7 +61,7 @@ plt.errorbar(param_range, test_errors.mean(axis=1),
 plt.legend()
 plt.ylabel("Mean absolute error in k$\n(smaller is better)")
 plt.xlabel("# estimators")
-_ = plt.title("Validation curve for AdaBoost regressor")
+_ = plt.title("Validation curve for AdaBoost regression model")
 
 # %% [markdown]
 # Plotting the validation curve, we can see that AdaBoost is not immune against
@@ -69,7 +69,7 @@ _ = plt.title("Validation curve for AdaBoost regressor")
 # Adding too many estimators is detrimental for the performance of the model.
 
 # %% [markdown]
-# Repeat the experiment using a random forest instead of an AdaBoost regressor.
+# Repeat the experiment using a random forest instead of an AdaBoost regression model.
 
 # %%
 from sklearn.ensemble import RandomForestRegressor
@@ -92,10 +92,10 @@ plt.errorbar(param_range, test_errors.mean(axis=1),
 plt.legend()
 plt.ylabel("Mean absolute error in k$\n(smaller is better)")
 plt.xlabel("# estimators")
-_ = plt.title("Validation curve for RandomForest regressor")
+_ = plt.title("Validation curve for RandomForest regression model")
 
 # %% [markdown]
-# In contrary to the AdaBoost regressor, we can see that increasing the number
+# In contrast to the AdaBoost regression model, we can see that increasing the number
 # trees in the forest will increase the generalization performance (by decreasing
 # the mean absolute error) of the random forest. In fact, a random forest has
 # less chance to suffer from overfitting than AdaBoost when increasing the

--- a/python_scripts/ensemble_sol_04.py
+++ b/python_scripts/ensemble_sol_04.py
@@ -68,7 +68,7 @@ plt.errorbar(
 plt.legend()
 plt.ylabel("Mean absolute error in k$\n(smaller is better)")
 plt.xlabel("# estimators")
-_ = plt.title("Validation curve for GBDT regressor")
+_ = plt.title("Validation curve for GBDT regression model")
 
 # %% [markdown]
 # Unlike AdaBoost, the gradient boosting model will always improve when

--- a/python_scripts/ensemble_sol_05.py
+++ b/python_scripts/ensemble_sol_05.py
@@ -15,7 +15,7 @@ data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$
 
 # %% [markdown]
-# First, create a histogram gradient boosting regressor. You can set the
+# First, create a histogram gradient boosting regression model. You can set the
 # trees number to be large, and configure the model to use early-stopping.
 
 # %%

--- a/python_scripts/feature_selection_introduction.py
+++ b/python_scripts/feature_selection_introduction.py
@@ -29,7 +29,7 @@ data, target = make_classification(
 #
 # We will create two machine learning pipelines. The former will be a random
 # forest that will use all available features. The latter will also be a random
-# forest, but we will add a feature selection step to train this classifier.
+# forest, but we will add a feature selection step to train this classification model.
 # The feature selection is based on a univariate test (ANOVA F-value) between
 # each feature and the target that we want to predict. The features with the
 # two most significant scores are selected.

--- a/python_scripts/linear_models_ex_04.py
+++ b/python_scripts/linear_models_ex_04.py
@@ -31,9 +31,9 @@ coef.plot.barh()
 coef
 
 # %% [markdown]
-# Create a `LinearRegression` regressor and fit on the entire dataset and
+# Create a `LinearRegression` regression model and fit on the entire dataset and
 # check the value of the coefficients. Are the coefficients of the linear
-# regressor close to the coefficients used to generate the dataset?
+# regression close to the coefficients used to generate the dataset?
 
 # %%
 from sklearn.linear_model import LinearRegression
@@ -61,14 +61,14 @@ _ = coef.plot.barh()
 # Write your code here.
 
 # %% [markdown]
-# Fit again the linear regressor on this new dataset and check the
+# Fit again the linear regression on this new dataset and check the
 # coefficients. What do you observe?
 
 # %%
 # Write your code here.
 
 # %% [markdown]
-# Create a ridge regressor and fit on the same dataset. Check the coefficients.
+# Create a ridge regression model and fit on the same dataset. Check the coefficients.
 # What do you observe?
 
 # %%

--- a/python_scripts/linear_models_ex_05.py
+++ b/python_scripts/linear_models_ex_05.py
@@ -1,11 +1,11 @@
 # %% [markdown]
 # # 📝 Exercise M4.05
 # In the previous notebook, we presented a non-penalized logistic regression
-# classifier. This classifier accepts a parameter `penalty` to add a
+# classification model. This model accepts a parameter `penalty` to add a
 # regularization. The regularization strength is set using the parameter `C`.
 #
 # In this exercise, we ask you to train a l2-penalized logistic regression
-# classifier and to find by yourself the effect of the parameter `C`.
+# classification model and to find by yourself the effect of the parameter `C`.
 #
 # We will start by loading the dataset and create the helper function to show
 # the decision separation as in the previous code.

--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -192,7 +192,7 @@ _ = plt.title("Ridge weights")
 # is generally good practice to scale the data.
 #
 # Thus, we will add a `StandardScaler` in the machine learning pipeline. This
-# scaler will be placed just before the regressor.
+# scaler will be placed just before the regression model.
 
 # %%
 from sklearn.preprocessing import StandardScaler
@@ -258,12 +258,12 @@ _ = plt.title("Ridge weights with data scaling")
 #
 # Therefore, we should include search of the hyperparameter `alpha` within the
 # cross-validation. As we saw in previous notebooks, we could use a
-# grid-search. However, some predictor in scikit-learn are available with
+# grid-search. However, some predictive models in scikit-learn are available with
 # an integrated hyperparameter search, more efficient than using a grid-search.
-# The name of these predictors finishes by `CV`. In the case of `Ridge`,
-# scikit-learn provides a `RidgeCV` regressor.
+# The name of these predictive models finishes by `CV`. In the case of `Ridge`,
+# scikit-learn provides a `RidgeCV` regression model.
 #
-# Therefore, we can use this predictor as the last step of the pipeline.
+# Therefore, we can use this predictive model as the last step of the pipeline.
 # Including the pipeline a cross-validation allows to make a nested
 # cross-validation: the inner cross-validation will search for the best
 # alpha, while the outer cross-validation will give an estimate of the
@@ -300,7 +300,7 @@ print(f"Mean squared error of linear regression model on the test set:\n"
 # By optimizing `alpha`, we see that the training and testing scores are close.
 # It indicates that our model is not overfitting.
 #
-# When fitting the ridge regressor, we also requested to store the error found
+# When fitting the ridge regression model, we also requested to store the error found
 # during cross-validation (by setting the parameter `store_cv_values=True`).
 # We will plot the mean squared error for the different `alphas` regularization
 # strength that we tried.

--- a/python_scripts/linear_models_sol_04.py
+++ b/python_scripts/linear_models_sol_04.py
@@ -36,9 +36,9 @@ coef.plot.barh()
 coef
 
 # %% [markdown]
-# Create a `LinearRegression` regressor and fit on the entire dataset and
+# Create a `LinearRegression` regression model and fit on the entire dataset and
 # check the value of the coefficients. Are the coefficients of the linear
-# regressor close to the coefficients used to generate the dataset?
+# regression model close to the coefficients used to generate the dataset?
 
 # %%
 from sklearn.linear_model import LinearRegression
@@ -68,7 +68,7 @@ import numpy as np
 data = np.concatenate([data, data[:, [0, 1]], data[:, [0, 1]]], axis=1)
 
 # %% [markdown]
-# Fit again the linear regressor on this new dataset and check the
+# Fit again the linear regression on this new dataset and check the
 # coefficients. What do you observe?
 
 # %%
@@ -93,7 +93,7 @@ _ = coef.plot.barh()
 # errors).
 
 # %% [markdown]
-# Create a ridge regressor and fit on the same dataset. Check the coefficients.
+# Create a ridge regression model and fit on the same dataset. Check the coefficients.
 # What do you observe?
 
 # %%

--- a/python_scripts/linear_models_sol_05.py
+++ b/python_scripts/linear_models_sol_05.py
@@ -1,11 +1,11 @@
 # %% [markdown]
 # # 📃 Solution for Exercise M4.05
 # In the previous notebook, we presented a non-penalized logistic regression
-# classifier. This classifier accepts a parameter `penalty` to add a
+# classification model. This model accepts a parameter `penalty` to add a
 # regularization. The regularization strength is set using the parameter `C`.
 #
 # In this exercise, we ask you to train a l2-penalized logistic regression
-# classifier and to find by yourself the effect of the parameter `C`.
+# classification model and to find by yourself the effect of the parameter `C`.
 #
 # We will start by loading the dataset and create the helper function to show
 # the decision separation as in the previous code.

--- a/python_scripts/linear_regression_non_linear_link.py
+++ b/python_scripts/linear_regression_non_linear_link.py
@@ -104,7 +104,7 @@ print(f"weight: {linear_regression.coef_[0]:.2f}, "
 # 3. use a "kernel" to have a locally-based decision function instead of a
 #    global linear decision function.
 #
-# Let's illustrate quickly the first point by using a decision tree regressor
+# Let's illustrate quickly the first point by using a decision tree regression model
 # which can natively handle non-linearity.
 
 # %%

--- a/python_scripts/logistic_regression.py
+++ b/python_scripts/logistic_regression.py
@@ -65,7 +65,7 @@ range_features = {
 }
 
 # %% [markdown]
-# To visualize the separation found by our classifier, we will define an helper
+# To visualize the separation found by our classification model, we will define an helper
 # function `plot_decision_function`. In short, this function will plot the edge
 # of the decision function, where the probability to be an Adelie or Chinstrap
 # will be equal (p=0.5).

--- a/python_scripts/logistic_regression_non_linear.py
+++ b/python_scripts/logistic_regression_non_linear.py
@@ -13,7 +13,7 @@
 # find a perfect linear separation.
 #
 # First, we redefine our plotting utility to show the decision boundary of a
-# classifier.
+# classification model.
 
 # %%
 import numpy as np
@@ -79,12 +79,12 @@ _ = plt.title("Illustration of the moons dataset")
 
 # %% [markdown]
 # From the intuitions that we got by studying linear model, it should be
-# obvious that a linear classifier will not be able to find a perfect decision
+# obvious that a linear classification model will not be able to find a perfect decision
 # function to separate the two classes.
 #
-# Let's try to see what is the decision boundary of such a linear classifier.
+# Let's try to see what is the decision boundary of such a linear model.
 # We will create a predictive model by standardizing the dataset followed by
-# a linear support vector machine classifier.
+# a linear support vector machine classification model.
 
 # %%
 from sklearn.pipeline import make_pipeline
@@ -96,7 +96,7 @@ linear_model.fit(data_moons, target_moons)
 
 # %% [markdown]
 # ```{warning}
-# Be aware that we fit and will check the boundary decision of the classifier
+# Be aware that we fit and will check the boundary decision of the classification model
 # on the same dataset without splitting the dataset into a training set and a
 # testing set. While this is a bad practice, we use it for the sake of
 # simplicity to depict the model behavior. Always use cross-validation when
@@ -158,7 +158,7 @@ _ = plt.title("Decision boundary of a linear model")
 # In the section about linear regression, we saw that we could use several
 # tricks to make a linear model more flexible by augmenting features or
 # using a kernel. Here, we will use the later solution by using a radial basis
-# function (RBF) kernel together with a support vector machine classifier.
+# function (RBF) kernel together with a support vector machine classification model.
 #
 # We will repeat the two previous experiments and check the obtained decision
 # function.
@@ -176,7 +176,7 @@ _ = plt.title("Decision boundary with a model using an RBF kernel")
 # %% [markdown]
 # We see that the decision boundary is not anymore a straight line. Indeed,
 # an area is defined around the red samples and we could imagine that this
-# classifier should be able to generalize on unseen data.
+# classification model should be able to generalize on unseen data.
 #
 # Let's check the decision function on the second dataset.
 
@@ -192,7 +192,7 @@ _ = plt.title("Decision boundary with a model using an RBF kernel")
 # is more flexible and does not underfit anymore.
 #
 # Thus, kernel trick or feature expansion are the tricks to make a linear
-# classifier more expressive, exactly as we saw in regression.
+# classification model more expressive, exactly as we saw in regression.
 #
 # Keep in mind that adding flexibility to a model can also risk increasing
 # overfitting by making the decision function to be sensitive to individual

--- a/python_scripts/metrics_classification.py
+++ b/python_scripts/metrics_classification.py
@@ -33,7 +33,7 @@ _ = plt.title("Number of samples per classes present\n in the target")
 
 # %% [markdown]
 # We can see that the vector `target` contains two classes corresponding to
-# whether a subject gave blood. We will use a logistic regression classifier to
+# whether a subject gave blood. We will use a logistic regression classification model to
 # predict this outcome.
 #
 # To focus on the metrics presentation, we will only use a single split instead
@@ -46,7 +46,7 @@ data_train, data_test, target_train, target_test = train_test_split(
     data, target, shuffle=True, random_state=0, test_size=0.5)
 
 # %% [markdown]
-# We will use a logistic regression classifier as a base model. We will train
+# We will use a logistic regression classification model as a base model. We will train
 # the model on the train set, and later use the test set to compute the
 # different classification metric.
 
@@ -57,9 +57,9 @@ classifier = LogisticRegression()
 classifier.fit(data_train, target_train)
 
 # %% [markdown]
-# ## Classifier predictions
+# ## classification model predictions
 # Before we go into details regarding the metrics, we will recall what type
-# of predictions a classifier can provide.
+# of predictions a classification model can provide.
 #
 # For this reason, we will create a synthetic sample for a new potential donor:
 # he/she donated blood twice in the past (1000 c.c. each time). The last time
@@ -69,20 +69,20 @@ classifier.fit(data_train, target_train)
 new_donor = [[6, 2, 1000, 20]]
 
 # %% [markdown]
-# We can get the class predicted by the classifier by calling the method
+# We can get the class predicted by the classification model by calling the method
 # `predict`.
 
 # %%
 classifier.predict(new_donor)
 
 # %% [markdown]
-# With this information, our classifier predicts that this synthetic subject
+# With this information, our classification model predicts that this synthetic subject
 # is more likely to not donate blood again.
 #
 # However, we cannot check whether the prediction is correct (we do not know
 # the true target value). That's the purpose of the testing set. First, we
 # predict whether a subject will give blood with the help of the trained
-# classifier.
+# classification model.
 
 # %%
 target_predicted = classifier.predict(data_test)
@@ -98,10 +98,10 @@ target_test == target_predicted
 
 # %% [markdown]
 # In the comparison above, a `True` value means that the value predicted by our
-# classifier is identical to the real value, while a `False` means that our
-# classifier made a mistake. One way of getting an overall rate representing
-# the generalization performance of our classifier would be to compute how many
-# times our classifier was right and divide it by the number of samples in our
+# classification model is identical to the real value, while a `False` means that our
+# model made a mistake. One way of getting an overall rate representing
+# the generalization performance of our classification model would be to compute how many
+# times it was right and divide it by the number of samples in our
 # set.
 
 # %%
@@ -110,7 +110,7 @@ import numpy as np
 np.mean(target_test == target_predicted)
 
 # %% [markdown]
-# This measure is called the accuracy. Here, our classifier is 78%
+# This measure is called the accuracy. Here, our classification model is 78%
 # accurate at classifying if a subject will give blood. `scikit-learn` provides
 # a function that computes this metric in the module `sklearn.metrics`.
 
@@ -130,8 +130,8 @@ classifier.score(data_test, target_test)
 # %% [markdown]
 # ## Confusion matrix and derived metrics
 # The comparison that we did above and the accuracy that we calculated did not
-# take into account the type of error our classifier was making. Accuracy
-# is an aggregate of the errors made by the classifier. We may be interested
+# take into account the type of error our classification model was making. Accuracy
+# is an aggregate of the errors made by the model. We may be interested
 # in finer granularity - to know independently what the error is for each of
 # the two following cases:
 #
@@ -150,26 +150,26 @@ _ = plot_confusion_matrix(classifier, data_test, target_test)
 # predictions:
 #
 # * the top left corner are true positives (TP) and corresponds to people
-#   who gave blood and were predicted as such by the classifier;
+#   who gave blood and were predicted as such by the classification model;
 # * the bottom right corner are true negatives (TN) and correspond to
 #   people who did not give blood and were predicted as such by the
-#   classifier;
+#   model;
 # * the top right corner are false negatives (FN) and correspond to
 #   people who gave blood but were predicted to not have given blood;
 # * the bottom left corner are false positives (FP) and correspond to
 #   people who did not give blood but were predicted to have given blood.
 #
 # Once we have split this information, we can compute metrics to highlight the
-# generalization performance of our classifier in a particular setting. For
+# generalization performance of our classification model in a particular setting. For
 # instance, we could be interested in the fraction of people who really gave
-# blood when the classifier predicted so or the fraction of people predicted to
+# blood when the model predicted so or the fraction of people predicted to
 # have given blood out of the total population that actually did so.
 #
 # The former metric, known as the precision, is defined as TP / (TP + FP)
-# and represents how likely the person actually gave blood when the classifier
+# and represents how likely the person actually gave blood when the classification model
 # predicted that they did.
 # The latter, known as the recall, defined as TP / (TP + FN) and
-# assesses how well the classifier is able to correctly identify people who
+# assesses how well the model is able to correctly identify people who
 # did give blood.
 # We could, similarly to accuracy, manually compute these values,
 # however scikit-learn provides functions to compute these statistics.
@@ -186,7 +186,7 @@ print(f"Recall score: {recall:.3f}")
 # %% [markdown]
 # These results are in line with what was seen in the confusion matrix. Looking
 # at the left column, more than half of the "donated" predictions were correct,
-# leading to a precision above 0.5. However, our classifier mislabeled a lot of
+# leading to a precision above 0.5. However, our classification model mislabeled a lot of
 # people who gave blood as "not donated", leading to a very low recall of
 # around 0.1.
 #
@@ -206,23 +206,23 @@ _ = plt.title("Class frequency in the training set")
 
 # %% [markdown]
 # We observe that the positive class, `'donated'`, comprises only 24% of the
-# samples. The good accuracy of our classifier is then linked to its ability to
+# samples. The good accuracy of our classification model is then linked to its ability to
 # correctly predict the negative class `'not donated'` which may or may not be
 # relevant, depending on the application. We can illustrate the issue using a
-# dummy classifier as a baseline.
+# dummy classification model as a baseline.
 
 # %%
 from sklearn.dummy import DummyClassifier
 
 dummy_classifier = DummyClassifier(strategy="most_frequent")
 dummy_classifier.fit(data_train, target_train)
-print(f"Accuracy of the dummy classifier: "
+print(f"Accuracy of the dummy classification model: "
       f"{dummy_classifier.score(data_test, target_test):.3f}")
 
 # %% [markdown]
-# With the dummy classifier, which always predicts the negative class `'not
+# With the dummy classification model, which always predicts the negative class `'not
 # donated'`, we obtain an accuracy score of 76%. Therefore, it means that this
-# classifier, without learning anything from the data `data`, is capable of
+# model, without learning anything from the data `data`, is capable of
 # predicting as accurately as our logistic regression model.
 #
 # The problem illustrated above is also known as the class imbalance problem.
@@ -244,9 +244,9 @@ print(f"Balanced accuracy: {balanced_accuracy:.3f}")
 # All statistics that we presented up to now rely on `classifier.predict` which
 # outputs the most likely label. We haven't made use of the probability
 # associated with this prediction, which gives the confidence of the
-# classifier in this prediction. By default, the prediction of a classifier
+# classification model in this prediction. By default, the prediction of a classification model
 # corresponds to a threshold of 0.5 probability in a binary classification
-# problem. We can quickly check this relationship with the classifier that
+# problem. We can quickly check this relation with the model that
 # we trained.
 
 # %%
@@ -269,7 +269,7 @@ np.all(equivalence_pred_proba)
 
 # %% [markdown]
 # The default decision threshold (0.5) might not be the best threshold that
-# leads to optimal generalization performance of our classifier. In this case, one
+# leads to optimal generalization performance of our classification model. In this case, one
 # can vary the decision threshold, and therefore the underlying prediction, and
 # compute the same statistics presented earlier. Usually, the two metrics
 # recall and precision are computed and plotted on a graph. Each metric plotted
@@ -298,9 +298,9 @@ _ = disp.ax_.set_title("Precision-recall curve")
 # used as a decision threshold. We can see that, by varying this decision
 # threshold, we get different precision vs. recall values.
 #
-# A perfect classifier would have a precision of 1 for all recall values. A
+# A perfect classification model would have a precision of 1 for all recall values. A
 # metric characterizing the curve is linked to the area under the curve (AUC)
-# and is named average precision (AP). With an ideal classifier, the average
+# and is named average precision (AP). With an ideal classification model, the average
 # precision would be 1.
 #
 # The precision and recall metric focuses on the positive class, however, one
@@ -329,7 +329,7 @@ _ = disp.ax_.set_title("ROC AUC curve")
 # we vary the probability threshold for determining "hard" prediction and
 # compute the metrics. As with the precision-recall curve, we can compute the
 # area under the ROC (ROC-AUC) to characterize the generalization performance of
-# our classifier. However, it is important to observe that the lower bound of
+# our classification model. However, it is important to observe that the lower bound of
 # the ROC-AUC is 0.5. Indeed, we show the generalization performance of a dummy
-# classifier (the orange dashed line) to show that even the worst generalization
+# classification model (the orange dashed line) to show that even the worst generalization
 # performance obtained will be above this line.

--- a/python_scripts/metrics_ex_01.py
+++ b/python_scripts/metrics_ex_01.py
@@ -21,7 +21,7 @@ target = blood_transfusion["Class"]
 # ```
 
 # %% [markdown]
-# First, create a decision tree classifier.
+# First, create a decision tree classification model.
 
 # %%
 # Write your code here.

--- a/python_scripts/metrics_regression.py
+++ b/python_scripts/metrics_regression.py
@@ -93,7 +93,7 @@ from sklearn.dummy import DummyRegressor
 
 dummy_regressor = DummyRegressor(strategy="mean")
 dummy_regressor.fit(data_train, target_train)
-print(f"R2 score for a regressor predicting the mean:"
+print(f"R2 score for a regression model predicting the mean:"
       f"{dummy_regressor.score(data_test, target_test):.3f}")
 
 # %% [markdown]

--- a/python_scripts/metrics_sol_01.py
+++ b/python_scripts/metrics_sol_01.py
@@ -21,7 +21,7 @@ target = blood_transfusion["Class"]
 # ```
 
 # %% [markdown]
-# First, create a decision tree classifier.
+# First, create a decision tree classification model.
 
 # %%
 from sklearn.tree import DecisionTreeClassifier

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -49,7 +49,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 # We will define a pipeline as seen in the first module. It will handle both
 # numerical and categorical features.
 #
-# As we will use a tree-based model as a predictor, here we apply an ordinal
+# As we will use a tree-based model as a predictive model, here we apply an ordinal
 # encoder on the categorical features: it encodes every category with an
 # arbitrary integer. For simple models such as linear models, a one-hot encoder
 # should be preferred. But for complex models, in particular tree-based models,
@@ -85,7 +85,7 @@ preprocessor = ColumnTransformer([
     remainder='passthrough', sparse_threshold=0)
 
 # %% [markdown]
-# Finally, we use a tree-based classifier (i.e. histogram gradient-boosting) to
+# Finally, we use a tree-based classification model (i.e. histogram gradient-boosting) to
 # predict whether or not a person earns more than 50 k$ a year.
 
 # %%
@@ -153,7 +153,7 @@ print(
 # combinations). Thus, adding new parameters with their associated values to be
 # explored become rapidly computationally expensive.
 #
-# Once the grid-search is fitted, it can be used as any other predictor by
+# Once the grid-search is fitted, it can be used as any other predictive model by
 # calling `predict` and `predict_proba`. Internally, it will use the model with
 # the best parameters found during `fit`.
 #

--- a/python_scripts/parameter_tuning_manual.py
+++ b/python_scripts/parameter_tuning_manual.py
@@ -32,7 +32,7 @@ data.head()
 
 # %% [markdown]
 # Let's create a simple predictive model made of a scaler followed by a
-# logistic regression classifier.
+# logistic regression classification model.
 #
 # As mentioned in previous notebooks, many models, including linear ones,
 # work better if all features have a similar scaling. For this purpose,

--- a/python_scripts/trees_classification.py
+++ b/python_scripts/trees_classification.py
@@ -32,12 +32,12 @@ range_features = {
     for feature_name in data.columns}
 
 # %% [markdown]
-# In a previous notebook, we learnt that a linear classifier will define a
+# In a previous notebook, we learnt that a linear classification model will define a
 # linear separation to split classes using a linear combination of the input
-# features. In our 2-dimensional space, it means that a linear classifier will
+# features. In our 2-dimensional space, it means that a linear classification model will
 # define some oblique lines that best separate our classes. We define a
-# function below that, given a set of data points and a classifier, will plot
-# the decision boundaries learnt by the classifier.
+# function below that, given a set of data points and a classification model, will plot
+# the decision boundaries learnt by the model.
 
 # %%
 import numpy as np
@@ -70,7 +70,7 @@ def plot_decision_function(fitted_classifier, range_features, ax=None):
 
 
 # %% [markdown]
-# Thus, for a linear classifier, we will obtain the following decision
+# Thus, for a linear classification model, we will obtain the following decision
 # boundaries. These boundaries lines indicate where the model changes its
 # prediction from one class to another.
 
@@ -165,7 +165,7 @@ _ = plot_tree(tree, feature_names=culmen_columns,
 # partition defined by a threshold inferior to 16.45mm. In this case, the most
 # represented class is the Gentoo species.
 #
-# Let's see how our tree would work as a predictor. Let's start to see the
+# Let's see how our tree would work as a predictive model. Let's start to see the
 # class predicted when the culmen depth is inferior to the threshold.
 
 # %%
@@ -181,7 +181,7 @@ tree.predict([[0, 17]])
 # %% [markdown]
 # In this case, the tree predicts the Adelie specie.
 #
-# Thus, we can conclude that a decision tree classifier will predict the most
+# Thus, we can conclude that a decision tree classification model will predict the most
 # represented class within a partition.
 #
 # During the training, we have a count of samples in each partition, we can

--- a/python_scripts/trees_ex_01.py
+++ b/python_scripts/trees_ex_01.py
@@ -68,8 +68,8 @@ def plot_decision_function(fitted_classifier, range_features, ax=None):
 
 
 # %% [markdown]
-# Create a decision tree classifier with a maximum depth of 2 levels and fit
-# the training data. Once this classifier trained, plot the data and the
+# Create a decision tree classification model with a maximum depth of 2 levels and fit
+# the training data. Once this model is trained, plot the data and the
 # decision boundary to see the benefit of increasing the depth.
 
 # %%

--- a/python_scripts/trees_sol_01.py
+++ b/python_scripts/trees_sol_01.py
@@ -70,8 +70,8 @@ def plot_decision_function(fitted_classifier, range_features, ax=None):
 
 
 # %% [markdown]
-# Create a decision tree classifier with a maximum depth of 2 levels and fit
-# the training data. Once this classifier trained, plot the data and the
+# Create a decision tree classification model with a maximum depth of 2 levels and fit
+# the training data. Once this model is trained, plot the data and the
 # decision boundary to see the benefit of increasing the depth.
 
 # %%


### PR DESCRIPTION
Fix #352 (Replace predictor, regressor, classifier for predictive model, regression model and classification model)

Fix wording related to replacement (for keeping readability)

Modify the glossary accordingly.

Fix couple of typos on the process.