### PR TITLE
Add JupyterBook table of contents

### DIFF
--- a/jupyter-book/index.md
+++ b/jupyter-book/index.md
@@ -91,3 +91,13 @@ Note however that it is required to use the
 [version hosted on the fun-mooc platform](
 https://www.fun-mooc.fr/en/courses/machine-learning-python-scikit-learn/)
 to complete the quizzes.
+
+
+``````{container} remove-from-content-only
+
+<h2 id="toc">Table of contents<a class="headerlink" href="#toc" title="Permalink to this headline">¶</a></h2>
+
+```{tableofcontents}
+```
+
+``````


### PR DESCRIPTION
Fix #335.

This is the simplest thing I found to add the table of contents.
- the `tableofcontents` JupyterBook directive only shows the table of contents of the current document so it needs to be in `index.md`
- Using the class `remove-from-content-only` so that this is not shown in FUN
- I tried different variations using a markdown heading but got a JupyterBook warning "WARNING: Header nested in this element can lead to unexpected outcomes" and it was not working as expected so I used some HTML directly

We could make it prettier with some CSS (for example make the module titles more visible) but let's leave this for another day.