### PR TITLE
Put table of contents outside of index.md

### DIFF
--- a/jupyter-book/_toc.yml
+++ b/jupyter-book/_toc.yml
@@ -1,6 +1,8 @@
 format: jb-book
-root: index
+root: toc
 parts:
+- chapters:
+  - file: index
 - caption: Machine Learning Concepts
   chapters:
   - file: ml_concepts/slides
@@ -239,3 +241,5 @@ parts:
     - file: python_scripts/datasets_blood_transfusion
     - file: python_scripts/datasets_bike_rides
   - file: appendix/acknowledgement
+  - file: appendix/notebook_timings
+  - file: appendix/toc_redirect

--- a/jupyter-book/appendix/notebook_timings.md
+++ b/jupyter-book/appendix/notebook_timings.md
@@ -1,2 +1,4 @@
+# Notebook timings
+
 ```{nb-exec-table}
 ```

--- a/jupyter-book/appendix/toc_redirect.md
+++ b/jupyter-book/appendix/toc_redirect.md
@@ -1,0 +1,3 @@
+<meta http-equiv="refresh" content="0; URL=../toc.html" />
+
+# Table of contents

--- a/jupyter-book/index.md
+++ b/jupyter-book/index.md
@@ -1,4 +1,4 @@
-# Intro
+# Introduction
 
 ## Course presentation
 
@@ -92,12 +92,3 @@ Note however that it is required to use the
 https://www.fun-mooc.fr/en/courses/machine-learning-python-scikit-learn/)
 to complete the quizzes.
 
-
-``````{container} remove-from-content-only
-
-<h2 id="toc">Table of contents<a class="headerlink" href="#toc" title="Permalink to this headline">¶</a></h2>
-
-```{tableofcontents}
-```
-
-``````

--- a/jupyter-book/toc.md
+++ b/jupyter-book/toc.md
@@ -1,0 +1,4 @@
+# Table of contents
+
+```{tableofcontents}
+```


### PR DESCRIPTION
- appendix/toc_redirect with an HTML redirect was the simplest way I found to add a link to the left hand side panel that goes to the table of contents. Otherwise the toc is accessible as `/toc.html`
- also add notebook timings to _toc.yml

The main thing is that the root document in `_toc.yml` (so `toc` in this PR, previously `index`) needs to be the place where the `tableofcontents` directive is used since this directive only show the table of contents for the current document.