### PR TITLE
Fix wording in linear models exercise for clarity

### DIFF
--- a/python_scripts/linear_models_ex_03.py
+++ b/python_scripts/linear_models_ex_03.py
@@ -29,17 +29,17 @@ target *= 100  # rescale the target in k$
 data.head()
 
 # %% [markdown]
-# Now this is your turn to train a linear regression model on this dataset.
+# Now it is your turn to train a linear regression model on this dataset.
 # You will need to:
 # * create a linear regression model;
 # * execute a cross-validation with 10 folds and use the mean absolute error
-#   (MAE) as metric. Ensure to return the fitted estimators;
-# * compute mean and std of the MAE in thousands of dollars (k$);
-# * show the values of the coefficients for each feature using a boxplot by
-#   inspecting the fitted model returned from the cross-validation. Hint: you
+#   (MAE) as metric. Be sure to *return* the fitted *estimators*;
+# * inspect the fitted model using a box plot to show the distribution of values
+#   for the coefficients returned from the cross-validation. Hint:
 #   use the function
 #   [`df.plot.box()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.plot.box.html)
-#   to plot a box plot.
+#   to create a box plot.
+# * compute mean and std of the MAE in thousands of dollars (k$);
 
 # %%
 # Write your code here.

--- a/python_scripts/linear_models_sol_03.py
+++ b/python_scripts/linear_models_sol_03.py
@@ -28,17 +28,17 @@ target *= 100  # rescale the target in k$
 data.head()
 
 # %% [markdown]
-# Now this is your turn to train a linear regression model on this dataset.
+# Now it is your turn to train a linear regression model on this dataset.
 # You will need to:
 # * create a linear regression model;
 # * execute a cross-validation with 10 folds and use the mean absolute error
-#   (MAE) as metric. Ensure to return the fitted estimators;
-# * compute mean and std of the MAE in thousands of dollars (k$);
-# * show the values of the coefficients for each feature using a boxplot by
-#   inspecting the fitted model returned from the cross-validation. Hint: you
+#   (MAE) as metric. Be sure to *return* the fitted *estimators*;
+# * inspect the fitted model using a box plot to show the distribution of values
+#   for the coefficients returned from the cross-validation. Hint:
 #   use the function
 #   [`df.plot.box()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.plot.box.html)
-#   to plot a box plot.
+#   to create a box plot.
+# * compute mean and std of the MAE in thousands of dollars (k$);
 
 # %%
 # solution
@@ -54,11 +54,6 @@ cv_results = cross_validate(linear_regression, data, target,
                             return_estimator=True, cv=10, n_jobs=2)
 
 # %% tags=["solution"]
-print(f"Mean absolute error on testing set: "
-      f"{-cv_results['test_score'].mean():.3f} k$ +/- "
-      f"{cv_results['test_score'].std():.3f}")
-
-# %% tags=["solution"]
 import pandas as pd
 
 weights = pd.DataFrame(
@@ -70,3 +65,8 @@ import matplotlib.pyplot as plt
 color = {"whiskers": "black", "medians": "black", "caps": "black"}
 weights.plot.box(color=color, vert=False)
 _ = plt.title("Value of linear regression coefficients")
+
+# %% tags=["solution"]
+print(f"Mean absolute error on testing set: "
+      f"{-cv_results['test_score'].mean():.3f} k$ +/- "
+      f"{cv_results['test_score'].std():.3f}")


### PR DESCRIPTION
Instructions in linear_models_ex_03.py were unclear. Rephrased to fix it and changed the order of two instructions to improve linearity of exposition.