### PR TITLE
Fix a/an before h

### DIFF
--- a/jupyter-book/appendix/glossary.md
+++ b/jupyter-book/appendix/glossary.md
@@ -47,7 +47,7 @@ the line: a [sample](#sample-instance-observation) lying on the left of the
 line will be predicted as a blue sample while a sample lying on the right of
 the line will be predicted as an orange sample. Here, we have a linear
 [classifier](#classifier) because the decision rule is defined as a line (in
-higher dimensions this would be an hyperplane). However, the shape of the
+higher dimensions this would be a hyperplane). However, the shape of the
 decision rule will depend on the [model](#model) used.
 
 ### classifier

--- a/jupyter-book/predictive_modeling_pipeline/wrap_up_quiz.md
+++ b/jupyter-book/predictive_modeling_pipeline/wrap_up_quiz.md
@@ -40,7 +40,7 @@ _Select several answers_
 +++
 
 ```{admonition} Question
-How many features are available to predict whether or not an house is
+How many features are available to predict whether or not a house is
 expensive?
 
 - a) 79

--- a/jupyter-book/tuning/parameter_tuning_module_intro.md
+++ b/jupyter-book/tuning/parameter_tuning_module_intro.md
@@ -44,7 +44,7 @@ The required technical skills to carry on this module are:
 The objective in the module are the following:
 
 - understand what is a model hyperparameter;
-- understand how to get and set the value an hyperparameter of a scikit-learn
+- understand how to get and set the value of a hyperparameter in a scikit-learn
   model;
 - be able to fine tune a full predictive modeling pipeline;
 - understand and visualize the combination of parameters that improves the

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -233,7 +233,7 @@ print(f"The test accuracy using a {model_name} is "
 # %% [markdown]
 # If we compare with the accuracy obtained by wrongly evaluating the model
 # on the training set, we find that this evaluation was indeed optimistic
-# compared to the score obtained on an held-out test set.
+# compared to the score obtained on a held-out test set.
 #
 # It shows the importance to always testing the generalization performance of
 # predictive models on a different set than the one used to train these models.

--- a/python_scripts/datasets_bike_rides.py
+++ b/python_scripts/datasets_bike_rides.py
@@ -193,5 +193,5 @@ _ = sns.pairplot(data=subset, hue="power", palette="viridis")
 # the a link between higher slope / high heart-rate and higher power: a cyclist
 # need to develop more energy to go uphill enforcing a stronger physiological
 # stimuli on the body. We can confirm this intuition by looking at the
-# interaction between the slope and the speed: a lower speed with an higher
+# interaction between the slope and the speed: a lower speed with a higher
 # slope is usually associated with higher power.

--- a/python_scripts/datasets_california_housing.py
+++ b/python_scripts/datasets_california_housing.py
@@ -96,7 +96,7 @@ california_housing.frame[features_of_interest].describe()
 
 # %% [markdown]
 # For each of these features, comparing the `max` and `75%` values, we can see
-# an huge difference. It confirms the intuitions that there are a couple of
+# a huge difference. It confirms the intuitions that there are a couple of
 # extreme values.
 #
 # Up to know, we discarded the longitude and latitude that carry geographical

--- a/python_scripts/logistic_regression.py
+++ b/python_scripts/logistic_regression.py
@@ -65,7 +65,7 @@ range_features = {
 }
 
 # %% [markdown]
-# To visualize the separation found by our classifier, we will define an helper
+# To visualize the separation found by our classifier, we will define a helper
 # function `plot_decision_function`. In short, this function will plot the edge
 # of the decision function, where the probability to be an Adelie or Chinstrap
 # will be equal (p=0.5).

--- a/python_scripts/metrics_regression.py
+++ b/python_scripts/metrics_regression.py
@@ -125,8 +125,8 @@ print(f"Median absolute error: "
 
 # %% [markdown]
 # The mean absolute error (or median absolute error) still have a known
-# limitation: committing an error of 50 k\$ for an house valued at 50 k\$ has the
-# same impact than committing an error of 50 k\$ for an house valued at 500 k\$.
+# limitation: committing an error of 50 k\$ for a house valued at 50 k\$ has the
+# same impact than committing an error of 50 k\$ for a house valued at 500 k\$.
 # Indeed, the mean absolute error is not relative.
 #
 # The mean absolute percentage error introduce this relative scaling.


### PR DESCRIPTION
Fix "a/an before h" rule (see [here](https://www.gramlee.com/blog/indefinite-articles-a-or-an-before-h-blame-the-confusion-on-the-french/) for example):

> However, words that start with the letter “H” do not follow the rule for consonants. For the letter “H”, the pronunciation dictates the indefinite article:
> 
>     Use “a” before words where you pronounce the letter “H” such as “a hat,” “a house” or “a happy cat.”
>     Use “an” before words where you don’t pronounce the letter “H” such as “an herb,” “an hour,” or “an honorable man.”