### PR TITLE
Add scoring model on test set

### DIFF
--- a/python_scripts/parameter_tuning_ex_02.py
+++ b/python_scripts/parameter_tuning_ex_02.py
@@ -66,13 +66,21 @@ model = Pipeline([
 # loops, make a search of the best combinations of the `learning_rate` and
 # `max_leaf_nodes` parameters. In this regard, you will need to train and test
 # the model by setting the parameters. The evaluation of the model should be
-# performed using `cross_val_score`. We will use the following parameters
-# search:
+# performed using `cross_val_score` inside the training set. We will use the
+# following parameters search:
 # - `learning_rate` for the values 0.01, 0.1, 1 and 10. This parameter controls
 #   the ability of a new tree to correct the error of the previous sequence of
 #   trees
 # - `max_leaf_nodes` for the values 3, 10, 30. This parameter controls the
 #   depth of each tree.
+
+# %%
+# Write your code here.
+
+# %% [markdown]
+#
+# Now use the test set to score the model using the best parameters
+# that we found using cross-validation in the training set.
 
 # %%
 # Write your code here.

--- a/python_scripts/parameter_tuning_sol_02.py
+++ b/python_scripts/parameter_tuning_sol_02.py
@@ -65,8 +65,8 @@ model = Pipeline([
 # loops, make a search of the best combinations of the `learning_rate` and
 # `max_leaf_nodes` parameters. In this regard, you will need to train and test
 # the model by setting the parameters. The evaluation of the model should be
-# performed using `cross_val_score`. We will use the following parameters
-# search:
+# performed using `cross_val_score` inside the training set. We will use the
+# following parameters search:
 # - `learning_rate` for the values 0.01, 0.1, 1 and 10. This parameter controls
 #   the ability of a new tree to correct the error of the previous sequence of
 #   trees
@@ -100,3 +100,20 @@ for lr in learning_rate:
 
 print(f"The best accuracy obtained is {best_score:.3f}")
 print(f"The best parameters found are:\n {best_params}")
+
+# %% [markdown]
+#
+# Now use the test set to score the model using the best parameters
+# that we found using cross-validation in the training set.
+
+# %%
+# solution
+best_lr = best_params['learning-rate']
+best_mln = best_params['max leaf nodes']
+
+model.set_params(classifier__learning_rate=best_lr,
+                classifier__max_leaf_nodes=best_mln)
+
+model.fit(data_train, target_train)
+
+model.score(data_test, target_test)


### PR DESCRIPTION
In the same line of thought as in #439, after finding the best parameter on the train-validation sets in [Exercise M3.01](https://inria.github.io/scikit-learn-mooc/python_scripts/parameter_tuning_ex_02.html) and its [solution](https://inria.github.io/scikit-learn-mooc/python_scripts/parameter_tuning_sol_02.html), we should ask the student to score it on the test set. Else the role of the initial train-test split is unclear.