### PR TITLE
Clarify the notation "data_test" when no train-test split is involved

### DIFF
--- a/jupyter-book/appendix/glossary.md
+++ b/jupyter-book/appendix/glossary.md
@@ -312,9 +312,9 @@ usually used in [classification](#classification) setting.
 
 ### test set
 
-The dataset used to evaluate the [generalization
-performance](#generalization-performance-predictive-performance-statistical-performance)
-of the [model](#model) after it is [trained](#train-learn-fit).
+The dataset used to make predictions of a [model](#model) after it is
+[trained](#train-learn-fit) and eventually evaluate its [generalization
+performance](#generalization-performance-predictive-performance-statistical-performance).
 
 ### train, learn, fit
 

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -21,7 +21,7 @@ rng = np.random.RandomState(1)
 
 
 def generate_data(n_samples=30):
-    """Generate synthetic dataset. Returns `data_train`, `data_test`,
+    """Generate synthetic dataset. Returns `data_train`, `data_range`,
     `target_train`."""
     x_min, x_max = -3, 3
     x = rng.uniform(x_min, x_max, size=n_samples)
@@ -30,18 +30,18 @@ def generate_data(n_samples=30):
     y /= y.std()
 
     data_train = pd.DataFrame(x, columns=["Feature"])
-    data_test = pd.DataFrame(
+    data_range = pd.DataFrame(
         np.linspace(x_max, x_min, num=300), columns=["Feature"])
     target_train = pd.Series(y, name="Target")
 
-    return data_train, data_test, target_train
+    return data_train, data_range, target_train
 
 
 # %%
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-data_train, data_test, target_train = generate_data(n_samples=30)
+data_train, data_range, target_train = generate_data(n_samples=30)
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 _ = plt.title("Synthetic regression dataset")
@@ -57,12 +57,12 @@ from sklearn.tree import DecisionTreeRegressor
 
 tree = DecisionTreeRegressor(max_depth=3, random_state=0)
 tree.fit(data_train, target_train)
-y_pred = tree.predict(data_test)
+y_pred = tree.predict(data_range)
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, y_pred, label="Fitted tree")
+plt.plot(data_range, y_pred, label="Fitted tree")
 plt.legend()
 _ = plt.title("Predictions by a single decision tree")
 
@@ -127,7 +127,7 @@ for bootstrap_idx in range(n_bootstraps):
 # unique samples in the bootstrap samples.
 
 # %%
-data_train_huge, data_test_huge, target_train_huge = generate_data(
+data_train_huge, data_range_huge, target_train_huge = generate_data(
     n_samples=100_000)
 data_bootstrap_sample, target_bootstrap_sample = bootstrap_sample(
     data_train_huge, target_train_huge)
@@ -163,15 +163,16 @@ for bootstrap_idx in range(n_bootstraps):
 
 # %% [markdown]
 #
-# Now that we created a bag of different trees, we can use each of the tree to
-# predict on the testing data. They shall give slightly different predictions.
+# Now that we created a bag of different trees, we can use each of the trees to
+# predict the samples within the range of data. They shall give slightly
+# different predictions.
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 for tree_idx, tree in enumerate(bag_of_trees):
-    tree_predictions = tree.predict(data_test)
-    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
+    tree_predictions = tree.predict(data_range)
+    plt.plot(data_range, tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
 
 plt.legend()
@@ -196,13 +197,13 @@ sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
 
 bag_predictions = []
 for tree_idx, tree in enumerate(bag_of_trees):
-    tree_predictions = tree.predict(data_test)
-    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
+    tree_predictions = tree.predict(data_range)
+    plt.plot(data_range, tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
     bag_predictions.append(tree_predictions)
 
 bag_predictions = np.mean(bag_predictions, axis=0)
-plt.plot(data_test, bag_predictions, label="Averaged predictions",
+plt.plot(data_range, bag_predictions, label="Averaged predictions",
          linestyle="-")
 plt.legend()
 _ = plt.title("Predictions of bagged trees")
@@ -236,13 +237,13 @@ _ = bagged_trees.fit(data_train, target_train)
 
 # %% [markdown]
 #
-# Let us visualize the predictions of the ensemble on the same test data:
+# Let us visualize the predictions of the ensemble on the same interval of data:
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
-bagged_trees_predictions = bagged_trees.predict(data_test)
-plt.plot(data_test, bagged_trees_predictions)
+bagged_trees_predictions = bagged_trees.predict(data_range)
+plt.plot(data_range, bagged_trees_predictions)
 
 _ = plt.title("Predictions from a bagging classifier")
 
@@ -259,15 +260,15 @@ _ = plt.title("Predictions from a bagging classifier")
 # %%
 for tree_idx, tree in enumerate(bagged_trees.estimators_):
     label = "Predictions of individual trees" if tree_idx == 0 else None
-    tree_predictions = tree.predict(data_test)
-    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.1,
+    tree_predictions = tree.predict(data_range)
+    plt.plot(data_range, tree_predictions, linestyle="--", alpha=0.1,
              color="tab:blue", label=label)
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
-bagged_trees_predictions = bagged_trees.predict(data_test)
-plt.plot(data_test, bagged_trees_predictions,
+bagged_trees_predictions = bagged_trees.predict(data_range)
+plt.plot(data_range, bagged_trees_predictions,
          color="tab:orange", label="Predictions of ensemble")
 _ = plt.legend()
 
@@ -329,17 +330,17 @@ _ = bagging.fit(data_train, target_train)
 
 # %%
 for i, regressor in enumerate(bagging.estimators_):
-    regressor_predictions = regressor.predict(data_test)
+    regressor_predictions = regressor.predict(data_range)
     base_model_line = plt.plot(
-        data_test, regressor_predictions, linestyle="--", alpha=0.2,
+        data_range, regressor_predictions, linestyle="--", alpha=0.2,
         label="Predictions of base models" if i == 0 else None,
         color="tab:blue"
     )
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-bagging_predictions = bagging.predict(data_test)
-plt.plot(data_test, bagging_predictions,
+bagging_predictions = bagging.predict(data_range)
+plt.plot(data_range, bagging_predictions,
          color="tab:orange", label="Predictions of ensemble")
 plt.ylim(target_train.min(), target_train.max())
 plt.legend()

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -60,10 +60,9 @@ tree.fit(data_train, target_train)
 y_pred = tree.predict(data_test)
 
 # %% [markdown]
-# Using the term "test" here refers to data that was not used for training.
-# It should not be confused with data coming from a train-test split, as it
-# was generated in equally-spaced intervals for the visual evaluation of the
-# predictions.
+# Remember that the term "test" here refers to data that was not used for
+# training and computing an evaluation metric on such a synthetic test set
+# would be meaningless.
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -21,7 +21,7 @@ rng = np.random.RandomState(1)
 
 
 def generate_data(n_samples=30):
-    """Generate synthetic dataset. Returns `data_train`, `data_range`,
+    """Generate synthetic dataset. Returns `data_train`, `data_test`,
     `target_train`."""
     x_min, x_max = -3, 3
     x = rng.uniform(x_min, x_max, size=n_samples)
@@ -30,18 +30,18 @@ def generate_data(n_samples=30):
     y /= y.std()
 
     data_train = pd.DataFrame(x, columns=["Feature"])
-    data_range = pd.DataFrame(
+    data_test = pd.DataFrame(
         np.linspace(x_max, x_min, num=300), columns=["Feature"])
     target_train = pd.Series(y, name="Target")
 
-    return data_train, data_range, target_train
+    return data_train, data_test, target_train
 
 
 # %%
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-data_train, data_range, target_train = generate_data(n_samples=30)
+data_train, data_test, target_train = generate_data(n_samples=30)
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 _ = plt.title("Synthetic regression dataset")
@@ -57,12 +57,18 @@ from sklearn.tree import DecisionTreeRegressor
 
 tree = DecisionTreeRegressor(max_depth=3, random_state=0)
 tree.fit(data_train, target_train)
-y_pred = tree.predict(data_range)
+y_pred = tree.predict(data_test)
+
+# %% [markdown]
+# Using the term "test" here refers to data that was not used for training.
+# It should not be confused with data coming from a train-test split, as it
+# was generated in equally-spaced intervals for the visual evaluation of the
+# predictions.
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_range, y_pred, label="Fitted tree")
+plt.plot(data_test, y_pred, label="Fitted tree")
 plt.legend()
 _ = plt.title("Predictions by a single decision tree")
 
@@ -127,7 +133,7 @@ for bootstrap_idx in range(n_bootstraps):
 # unique samples in the bootstrap samples.
 
 # %%
-data_train_huge, data_range_huge, target_train_huge = generate_data(
+data_train_huge, data_test_huge, target_train_huge = generate_data(
     n_samples=100_000)
 data_bootstrap_sample, target_bootstrap_sample = bootstrap_sample(
     data_train_huge, target_train_huge)
@@ -171,8 +177,8 @@ for bootstrap_idx in range(n_bootstraps):
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 for tree_idx, tree in enumerate(bag_of_trees):
-    tree_predictions = tree.predict(data_range)
-    plt.plot(data_range, tree_predictions, linestyle="--", alpha=0.8,
+    tree_predictions = tree.predict(data_test)
+    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
 
 plt.legend()
@@ -197,13 +203,13 @@ sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
 
 bag_predictions = []
 for tree_idx, tree in enumerate(bag_of_trees):
-    tree_predictions = tree.predict(data_range)
-    plt.plot(data_range, tree_predictions, linestyle="--", alpha=0.8,
+    tree_predictions = tree.predict(data_test)
+    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
     bag_predictions.append(tree_predictions)
 
 bag_predictions = np.mean(bag_predictions, axis=0)
-plt.plot(data_range, bag_predictions, label="Averaged predictions",
+plt.plot(data_test, bag_predictions, label="Averaged predictions",
          linestyle="-")
 plt.legend()
 _ = plt.title("Predictions of bagged trees")
@@ -242,8 +248,8 @@ _ = bagged_trees.fit(data_train, target_train)
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
-bagged_trees_predictions = bagged_trees.predict(data_range)
-plt.plot(data_range, bagged_trees_predictions)
+bagged_trees_predictions = bagged_trees.predict(data_test)
+plt.plot(data_test, bagged_trees_predictions)
 
 _ = plt.title("Predictions from a bagging classifier")
 
@@ -260,15 +266,15 @@ _ = plt.title("Predictions from a bagging classifier")
 # %%
 for tree_idx, tree in enumerate(bagged_trees.estimators_):
     label = "Predictions of individual trees" if tree_idx == 0 else None
-    tree_predictions = tree.predict(data_range)
-    plt.plot(data_range, tree_predictions, linestyle="--", alpha=0.1,
+    tree_predictions = tree.predict(data_test)
+    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.1,
              color="tab:blue", label=label)
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
-bagged_trees_predictions = bagged_trees.predict(data_range)
-plt.plot(data_range, bagged_trees_predictions,
+bagged_trees_predictions = bagged_trees.predict(data_test)
+plt.plot(data_test, bagged_trees_predictions,
          color="tab:orange", label="Predictions of ensemble")
 _ = plt.legend()
 
@@ -330,17 +336,17 @@ _ = bagging.fit(data_train, target_train)
 
 # %%
 for i, regressor in enumerate(bagging.estimators_):
-    regressor_predictions = regressor.predict(data_range)
+    regressor_predictions = regressor.predict(data_test)
     base_model_line = plt.plot(
-        data_range, regressor_predictions, linestyle="--", alpha=0.2,
+        data_test, regressor_predictions, linestyle="--", alpha=0.2,
         label="Predictions of base models" if i == 0 else None,
         color="tab:blue"
     )
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-bagging_predictions = bagging.predict(data_range)
-plt.plot(data_range, bagging_predictions,
+bagging_predictions = bagging.predict(data_test)
+plt.plot(data_test, bagging_predictions,
          color="tab:orange", label="Predictions of ensemble")
 plt.ylim(target_train.min(), target_train.max())
 plt.legend()

--- a/python_scripts/ensemble_gradient_boosting.py
+++ b/python_scripts/ensemble_gradient_boosting.py
@@ -24,7 +24,7 @@ rng = np.random.RandomState(0)
 
 
 def generate_data(n_samples=50):
-    """Generate synthetic dataset. Returns `data_train`, `data_range`,
+    """Generate synthetic dataset. Returns `data_train`, `data_test`,
     `target_train`."""
     x_max, x_min = 1.4, -1.4
     len_x = x_max - x_min
@@ -33,14 +33,14 @@ def generate_data(n_samples=50):
     y = x ** 3 - 0.5 * x ** 2 + noise
 
     data_train = pd.DataFrame(x, columns=["Feature"])
-    data_range = pd.DataFrame(np.linspace(x_max, x_min, num=300),
+    data_test = pd.DataFrame(np.linspace(x_max, x_min, num=300),
                              columns=["Feature"])
     target_train = pd.Series(y, name="Target")
 
-    return data_train, data_range, target_train
+    return data_train, data_test, target_train
 
 
-data_train, data_range, target_train = generate_data()
+data_train, data_test, target_train = generate_data()
 
 # %%
 import matplotlib.pyplot as plt
@@ -62,22 +62,20 @@ tree = DecisionTreeRegressor(max_depth=3, random_state=0)
 tree.fit(data_train, target_train)
 
 target_train_predicted = tree.predict(data_train)
-target_test_predicted = tree.predict(data_range)
+target_test_predicted = tree.predict(data_test)
 
 # %% [markdown]
-# ```{warning}
 # Using the term "test" here refers to data that was not used for training.
 # It should not be confused with data coming from a train-test split, as it
 # was generated in equally-spaced intervals for the visual evaluation of the
 # predictions.
-# ```
 
 # %%
 # plot the data
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 # plot the predictions
-line_predictions = plt.plot(data_range, target_test_predicted, "--")
+line_predictions = plt.plot(data_test, target_test_predicted, "--")
 
 # plot the residuals
 for value, true, predicted in zip(data_train["Feature"],
@@ -114,11 +112,11 @@ tree_residuals = DecisionTreeRegressor(max_depth=5, random_state=0)
 tree_residuals.fit(data_train, residuals)
 
 target_train_predicted_residuals = tree_residuals.predict(data_train)
-target_test_predicted_residuals = tree_residuals.predict(data_range)
+target_test_predicted_residuals = tree_residuals.predict(data_test)
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=residuals, color="black", alpha=0.5)
-line_predictions = plt.plot(data_range, target_test_predicted_residuals, "--")
+line_predictions = plt.plot(data_test, target_test_predicted_residuals, "--")
 
 # plot the residuals of the predicted residuals
 for value, true, predicted in zip(data_train["Feature"],
@@ -155,7 +153,7 @@ target_true_residual = residuals.iloc[-2]
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_range, target_test_predicted, "--")
+plt.plot(data_test, target_test_predicted, "--")
 for value, true, predicted in zip(data_train["Feature"],
                                   target_train,
                                   target_train_predicted):
@@ -180,7 +178,7 @@ _ = plt.title("Tree predictions")
 
 sns.scatterplot(x=data_train["Feature"], y=residuals,
                 color="black", alpha=0.5)
-plt.plot(data_range, target_test_predicted_residuals, "--")
+plt.plot(data_test, target_test_predicted_residuals, "--")
 for value, true, predicted in zip(data_train["Feature"],
                                   residuals,
                                   target_train_predicted_residuals):

--- a/python_scripts/ensemble_gradient_boosting.py
+++ b/python_scripts/ensemble_gradient_boosting.py
@@ -24,7 +24,7 @@ rng = np.random.RandomState(0)
 
 
 def generate_data(n_samples=50):
-    """Generate synthetic dataset. Returns `data_train`, `data_test`,
+    """Generate synthetic dataset. Returns `data_train`, `data_range`,
     `target_train`."""
     x_max, x_min = 1.4, -1.4
     len_x = x_max - x_min
@@ -33,14 +33,14 @@ def generate_data(n_samples=50):
     y = x ** 3 - 0.5 * x ** 2 + noise
 
     data_train = pd.DataFrame(x, columns=["Feature"])
-    data_test = pd.DataFrame(np.linspace(x_max, x_min, num=300),
+    data_range = pd.DataFrame(np.linspace(x_max, x_min, num=300),
                              columns=["Feature"])
     target_train = pd.Series(y, name="Target")
 
-    return data_train, data_test, target_train
+    return data_train, data_range, target_train
 
 
-data_train, data_test, target_train = generate_data()
+data_train, data_range, target_train = generate_data()
 
 # %%
 import matplotlib.pyplot as plt
@@ -62,14 +62,22 @@ tree = DecisionTreeRegressor(max_depth=3, random_state=0)
 tree.fit(data_train, target_train)
 
 target_train_predicted = tree.predict(data_train)
-target_test_predicted = tree.predict(data_test)
+target_test_predicted = tree.predict(data_range)
+
+# %% [markdown]
+# ```{warning}
+# Using the term "test" here refers to data that was not used for training.
+# It should not be confused with data coming from a train-test split, as it
+# was generated in equally-spaced intervals for the visual evaluation of the
+# predictions.
+# ```
 
 # %%
 # plot the data
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 # plot the predictions
-line_predictions = plt.plot(data_test, target_test_predicted, "--")
+line_predictions = plt.plot(data_range, target_test_predicted, "--")
 
 # plot the residuals
 for value, true, predicted in zip(data_train["Feature"],
@@ -106,11 +114,11 @@ tree_residuals = DecisionTreeRegressor(max_depth=5, random_state=0)
 tree_residuals.fit(data_train, residuals)
 
 target_train_predicted_residuals = tree_residuals.predict(data_train)
-target_test_predicted_residuals = tree_residuals.predict(data_test)
+target_test_predicted_residuals = tree_residuals.predict(data_range)
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=residuals, color="black", alpha=0.5)
-line_predictions = plt.plot(data_test, target_test_predicted_residuals, "--")
+line_predictions = plt.plot(data_range, target_test_predicted_residuals, "--")
 
 # plot the residuals of the predicted residuals
 for value, true, predicted in zip(data_train["Feature"],
@@ -147,7 +155,7 @@ target_true_residual = residuals.iloc[-2]
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, target_test_predicted, "--")
+plt.plot(data_range, target_test_predicted, "--")
 for value, true, predicted in zip(data_train["Feature"],
                                   target_train,
                                   target_train_predicted):
@@ -172,7 +180,7 @@ _ = plt.title("Tree predictions")
 
 sns.scatterplot(x=data_train["Feature"], y=residuals,
                 color="black", alpha=0.5)
-plt.plot(data_test, target_test_predicted_residuals, "--")
+plt.plot(data_range, target_test_predicted_residuals, "--")
 for value, true, predicted in zip(data_train["Feature"],
                                   residuals,
                                   target_train_predicted_residuals):

--- a/python_scripts/ensemble_sol_02.py
+++ b/python_scripts/ensemble_sol_02.py
@@ -62,13 +62,13 @@ print(f"Mean absolute error: "
 # solution
 import numpy as np
 
-data_ranges = pd.DataFrame(np.linspace(170, 235, num=300),
+data_range = pd.DataFrame(np.linspace(170, 235, num=300),
                            columns=data.columns)
 tree_predictions = []
 for tree in forest.estimators_:
-    tree_predictions.append(tree.predict(data_ranges))
+    tree_predictions.append(tree.predict(data_range))
 
-forest_predictions = forest.predict(data_ranges)
+forest_predictions = forest.predict(data_range)
 
 # %% [markdown] tags=["solution"]
 # Now, we can plot the predictions that we collected.
@@ -82,8 +82,8 @@ sns.scatterplot(data=penguins, x=feature_names[0], y=target_name,
 
 # plot tree predictions
 for tree_idx, predictions in enumerate(tree_predictions):
-    plt.plot(data_ranges, predictions, label=f"Tree #{tree_idx}",
+    plt.plot(data_range, predictions, label=f"Tree #{tree_idx}",
              linestyle="--", alpha=0.8)
 
-plt.plot(data_ranges, forest_predictions, label=f"Random forest")
+plt.plot(data_range, forest_predictions, label=f"Random forest")
 _ = plt.legend()

--- a/python_scripts/trees_ex_02.py
+++ b/python_scripts/trees_ex_02.py
@@ -44,7 +44,7 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 
 # %% [markdown]
 # Create a scatter plot containing the training samples and superimpose the
-# predictions of both model on the top.
+# predictions of both models on the top.
 
 # %%
 # Write your code here.

--- a/python_scripts/trees_ex_02.py
+++ b/python_scripts/trees_ex_02.py
@@ -35,9 +35,9 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 # Write your code here.
 
 # %% [markdown]
-# Create a testing dataset, ranging from the minimum to the maximum of the
+# Create a dataset ranging from the minimum to the maximum of the
 # flipper length of the training dataset. Get the predictions of each model
-# using this test dataset.
+# using this dataset.
 
 # %%
 # Write your code here.
@@ -51,15 +51,15 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 
 # %% [markdown]
 # Now, we will check the extrapolation capabilities of each model. Create a
-# dataset containing the value of your previous dataset. Besides, add values
-# below and above the minimum and the maximum of the flipper length seen
-# during training.
+# dataset containing the same range of values as your previous dataset.
+# Besides, add values below and above the minimum and the maximum of the
+# flipper length seen during training.
 
 # %%
 # Write your code here.
 
 # %% [markdown]
-# Finally, make predictions with both models on this new testing set. Repeat
+# Finally, make predictions with both models on this new ranging set. Repeat
 # the plotting of the previous exercise.
 
 # %%

--- a/python_scripts/trees_ex_02.py
+++ b/python_scripts/trees_ex_02.py
@@ -35,9 +35,9 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 # Write your code here.
 
 # %% [markdown]
-# Create a dataset ranging from the minimum to the maximum of the
-# flipper length of the training dataset. Get the predictions of each model
-# using this dataset.
+# Create a synthetic dataset containing all possible flipper length from
+# the minimum to the maximum of the training dataset. Get the predictions of
+# each model using this dataset.
 
 # %%
 # Write your code here.
@@ -51,16 +51,16 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 
 # %% [markdown]
 # Now, we will check the extrapolation capabilities of each model. Create a
-# dataset containing the same range of values as your previous dataset.
-# Besides, add values below and above the minimum and the maximum of the
-# flipper length seen during training.
+# dataset containing a broader range of values than your previous dataset,
+# in other words, add values below and above the minimum and the maximum of
+# the flipper length seen during training.
 
 # %%
 # Write your code here.
 
 # %% [markdown]
-# Finally, make predictions with both models on this new ranging set. Repeat
-# the plotting of the previous exercise.
+# Finally, make predictions with both models on this new interval of data.
+# Repeat the plotting of the previous exercise.
 
 # %%
 # Write your code here.

--- a/python_scripts/trees_hyperparameters.py
+++ b/python_scripts/trees_hyperparameters.py
@@ -79,16 +79,16 @@ def plot_classification(model, X, y, ax=None):
 def plot_regression(model, X, y, ax=None):
     model.fit(X, y)
 
-    X_range = pd.DataFrame(
+    X_test = pd.DataFrame(
         np.arange(X.iloc[:, 0].min(), X.iloc[:, 0].max()),
         columns=X.columns,
     )
-    y_pred = model.predict(X_range)
+    y_pred = model.predict(X_test)
 
     if ax is None:
         _, ax = plt.subplots()
     sns.scatterplot(x=X.iloc[:, 0], y=y, color="black", alpha=0.5, ax=ax)
-    ax.plot(X_range, y_pred, linewidth=4)
+    ax.plot(X_test, y_pred, linewidth=4)
 
     return ax
 

--- a/python_scripts/trees_hyperparameters.py
+++ b/python_scripts/trees_hyperparameters.py
@@ -79,16 +79,16 @@ def plot_classification(model, X, y, ax=None):
 def plot_regression(model, X, y, ax=None):
     model.fit(X, y)
 
-    X_test = pd.DataFrame(
+    X_range = pd.DataFrame(
         np.arange(X.iloc[:, 0].min(), X.iloc[:, 0].max()),
         columns=X.columns,
     )
-    y_pred = model.predict(X_test)
+    y_pred = model.predict(X_range)
 
     if ax is None:
         _, ax = plt.subplots()
     sns.scatterplot(x=X.iloc[:, 0], y=y, color="black", alpha=0.5, ax=ax)
-    ax.plot(X_test, y_pred, linewidth=4)
+    ax.plot(X_range, y_pred, linewidth=4)
 
     return ax
 

--- a/python_scripts/trees_regression.py
+++ b/python_scripts/trees_regression.py
@@ -41,6 +41,14 @@ data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
 # It should not be confused with data coming from a train-test split, as it
 # was generated in equally-spaced intervals for the visual evaluation of the
 # predictions.
+#
+# Note that this is methodologically valid here because our objective is to get
+# some intuitive understanding on the shape of the decision function of the
+# learned decision trees.
+#
+# However computing an evaluation metric on such a synthetic test set would
+# be meaningless since the synthetic dataset does not follow the same
+# distribution as the real world data on which the model will be deployed.
 
 # %%
 import matplotlib.pyplot as plt

--- a/python_scripts/trees_regression.py
+++ b/python_scripts/trees_regression.py
@@ -32,9 +32,15 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 # %%
 import numpy as np
 
-data_range = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
+data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
                                    data_train[data_columns[0]].max()),
                          columns=data_columns)
+
+# %% [markdown]
+# Using the term "test" here refers to data that was not used for training.
+# It should not be confused with data coming from a train-test split, as it
+# was generated in equally-spaced intervals for the visual evaluation of the
+# predictions.
 
 # %%
 import matplotlib.pyplot as plt
@@ -53,12 +59,12 @@ from sklearn.linear_model import LinearRegression
 
 linear_model = LinearRegression()
 linear_model.fit(data_train, target_train)
-target_predicted = linear_model.predict(data_range)
+target_predicted = linear_model.predict(data_test)
 
 # %%
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_range, target_predicted, label="Linear regression")
+plt.plot(data_test, target_predicted, label="Linear regression")
 plt.legend()
 _ = plt.title("Prediction function using a LinearRegression")
 
@@ -71,9 +77,9 @@ _ = plt.title("Prediction function using a LinearRegression")
 # %%
 ax = sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                      color="black", alpha=0.5)
-plt.plot(data_range, target_predicted, label="Linear regression",
+plt.plot(data_test, target_predicted, label="Linear regression",
          linestyle="--")
-plt.scatter(data_range[::3], target_predicted[::3], label="Predictions",
+plt.scatter(data_test[::3], target_predicted[::3], label="Predictions",
             color="tab:orange")
 plt.legend()
 _ = plt.title("Prediction function using a LinearRegression")
@@ -89,12 +95,12 @@ from sklearn.tree import DecisionTreeRegressor
 
 tree = DecisionTreeRegressor(max_depth=1)
 tree.fit(data_train, target_train)
-target_predicted = tree.predict(data_range)
+target_predicted = tree.predict(data_test)
 
 # %%
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_range, target_predicted, label="Decision tree")
+plt.plot(data_test, target_predicted, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction function using a DecisionTreeRegressor")
 
@@ -126,12 +132,12 @@ _ = plot_tree(tree, feature_names=data_columns, ax=ax)
 # %%
 tree = DecisionTreeRegressor(max_depth=3)
 tree.fit(data_train, target_train)
-target_predicted = tree.predict(data_range)
+target_predicted = tree.predict(data_test)
 
 # %%
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_range, target_predicted, label="Decision tree")
+plt.plot(data_test, target_predicted, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction function using a DecisionTreeRegressor")
 

--- a/python_scripts/trees_regression.py
+++ b/python_scripts/trees_regression.py
@@ -32,7 +32,7 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 # %%
 import numpy as np
 
-data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
+data_range = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
                                    data_train[data_columns[0]].max()),
                          columns=data_columns)
 
@@ -53,12 +53,12 @@ from sklearn.linear_model import LinearRegression
 
 linear_model = LinearRegression()
 linear_model.fit(data_train, target_train)
-target_predicted = linear_model.predict(data_test)
+target_predicted = linear_model.predict(data_range)
 
 # %%
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Linear regression")
+plt.plot(data_range, target_predicted, label="Linear regression")
 plt.legend()
 _ = plt.title("Prediction function using a LinearRegression")
 
@@ -71,9 +71,9 @@ _ = plt.title("Prediction function using a LinearRegression")
 # %%
 ax = sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                      color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Linear regression",
+plt.plot(data_range, target_predicted, label="Linear regression",
          linestyle="--")
-plt.scatter(data_test[::3], target_predicted[::3], label="Test predictions",
+plt.scatter(data_range[::3], target_predicted[::3], label="Predictions",
             color="tab:orange")
 plt.legend()
 _ = plt.title("Prediction function using a LinearRegression")
@@ -89,12 +89,12 @@ from sklearn.tree import DecisionTreeRegressor
 
 tree = DecisionTreeRegressor(max_depth=1)
 tree.fit(data_train, target_train)
-target_predicted = tree.predict(data_test)
+target_predicted = tree.predict(data_range)
 
 # %%
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Decision tree")
+plt.plot(data_range, target_predicted, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction function using a DecisionTreeRegressor")
 
@@ -126,12 +126,12 @@ _ = plot_tree(tree, feature_names=data_columns, ax=ax)
 # %%
 tree = DecisionTreeRegressor(max_depth=3)
 tree.fit(data_train, target_train)
-target_predicted = tree.predict(data_test)
+target_predicted = tree.predict(data_range)
 
 # %%
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Decision tree")
+plt.plot(data_range, target_predicted, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction function using a DecisionTreeRegressor")
 

--- a/python_scripts/trees_sol_02.py
+++ b/python_scripts/trees_sol_02.py
@@ -42,21 +42,21 @@ linear_regression.fit(data_train, target_train)
 tree.fit(data_train, target_train)
 
 # %% [markdown]
-# Create a dataset ranging from the minimum to the maximum of the
-# flipper length of the training dataset. Get the predictions of each model
-# using this dataset.
+# Create a synthetic dataset containing all possible flipper length from
+# the minimum to the maximum of the training dataset. Get the predictions of
+# each model using this dataset.
 
 # %%
 # solution
 import numpy as np
 
-data_range = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
+data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
                                    data_train[data_columns[0]].max()),
                          columns=data_columns)
 
 # %% tags=["solution"]
-target_predicted_linear_regression = linear_regression.predict(data_range)
-target_predicted_tree = tree.predict(data_range)
+target_predicted_linear_regression = linear_regression.predict(data_test)
+target_predicted_tree = tree.predict(data_test)
 
 # %% [markdown]
 # Create a scatter plot containing the training samples and superimpose the
@@ -69,9 +69,9 @@ import seaborn as sns
 
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_range, target_predicted_linear_regression,
+plt.plot(data_test, target_predicted_linear_regression,
          label="Linear regression")
-plt.plot(data_range, target_predicted_tree, label="Decision tree")
+plt.plot(data_test, target_predicted_tree, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction of linear model and a decision tree")
 
@@ -83,31 +83,31 @@ _ = plt.title("Prediction of linear model and a decision tree")
 # %% [markdown]
 # Now, we will check the extrapolation capabilities of each model. Create a
 # dataset containing the same range of values as your previous dataset.
-# Besides, add values below and above the minimum and the maximum of the
+# Besides, add values beyond the minimum and the maximum of the
 # flipper length seen during training.
 
 # %%
 # solution
 offset = 30
-data_range = pd.DataFrame(np.arange(data_train[data_columns[0]].min() - offset,
+data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min() - offset,
                                    data_train[data_columns[0]].max() + offset),
                          columns=data_columns)
 
 # %% [markdown]
-# Finally, make predictions with both models on this new ranging set. Repeat
+# Finally, make predictions with both models on this new synthetic set. Repeat
 # the plotting of the previous exercise.
 
 # %%
 # solution
-target_predicted_linear_regression = linear_regression.predict(data_range)
-target_predicted_tree = tree.predict(data_range)
+target_predicted_linear_regression = linear_regression.predict(data_test)
+target_predicted_tree = tree.predict(data_test)
 
 # %% tags=["solution"]
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_range, target_predicted_linear_regression,
+plt.plot(data_test, target_predicted_linear_regression,
          label="Linear regression")
-plt.plot(data_range, target_predicted_tree, label="Decision tree")
+plt.plot(data_test, target_predicted_tree, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction of linear model and a decision tree")
 

--- a/python_scripts/trees_sol_02.py
+++ b/python_scripts/trees_sol_02.py
@@ -60,7 +60,7 @@ target_predicted_tree = tree.predict(data_range)
 
 # %% [markdown]
 # Create a scatter plot containing the training samples and superimpose the
-# predictions of both model on the top.
+# predictions of both models on the top.
 
 # %%
 # solution

--- a/python_scripts/trees_sol_02.py
+++ b/python_scripts/trees_sol_02.py
@@ -82,9 +82,9 @@ _ = plt.title("Prediction of linear model and a decision tree")
 
 # %% [markdown]
 # Now, we will check the extrapolation capabilities of each model. Create a
-# dataset containing the same range of values as your previous dataset.
-# Besides, add values beyond the minimum and the maximum of the
-# flipper length seen during training.
+# dataset containing a broader range of values than your previous dataset,
+# in other words, add values below and above the minimum and the maximum of
+# the flipper length seen during training.
 
 # %%
 # solution
@@ -94,8 +94,8 @@ data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min() - offset,
                          columns=data_columns)
 
 # %% [markdown]
-# Finally, make predictions with both models on this new synthetic set. Repeat
-# the plotting of the previous exercise.
+# Finally, make predictions with both models on this new interval of data.
+# Repeat the plotting of the previous exercise.
 
 # %%
 # solution

--- a/python_scripts/trees_sol_02.py
+++ b/python_scripts/trees_sol_02.py
@@ -42,21 +42,21 @@ linear_regression.fit(data_train, target_train)
 tree.fit(data_train, target_train)
 
 # %% [markdown]
-# Create a testing dataset, ranging from the minimum to the maximum of the
+# Create a dataset ranging from the minimum to the maximum of the
 # flipper length of the training dataset. Get the predictions of each model
-# using this test dataset.
+# using this dataset.
 
 # %%
 # solution
 import numpy as np
 
-data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
+data_range = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
                                    data_train[data_columns[0]].max()),
                          columns=data_columns)
 
 # %% tags=["solution"]
-target_predicted_linear_regression = linear_regression.predict(data_test)
-target_predicted_tree = tree.predict(data_test)
+target_predicted_linear_regression = linear_regression.predict(data_range)
+target_predicted_tree = tree.predict(data_range)
 
 # %% [markdown]
 # Create a scatter plot containing the training samples and superimpose the
@@ -69,9 +69,9 @@ import seaborn as sns
 
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted_linear_regression,
+plt.plot(data_range, target_predicted_linear_regression,
          label="Linear regression")
-plt.plot(data_test, target_predicted_tree, label="Decision tree")
+plt.plot(data_range, target_predicted_tree, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction of linear model and a decision tree")
 
@@ -82,32 +82,32 @@ _ = plt.title("Prediction of linear model and a decision tree")
 
 # %% [markdown]
 # Now, we will check the extrapolation capabilities of each model. Create a
-# dataset containing the value of your previous dataset. Besides, add values
-# below and above the minimum and the maximum of the flipper length seen
-# during training.
+# dataset containing the same range of values as your previous dataset.
+# Besides, add values below and above the minimum and the maximum of the
+# flipper length seen during training.
 
 # %%
 # solution
 offset = 30
-data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min() - offset,
+data_range = pd.DataFrame(np.arange(data_train[data_columns[0]].min() - offset,
                                    data_train[data_columns[0]].max() + offset),
                          columns=data_columns)
 
 # %% [markdown]
-# Finally, make predictions with both models on this new testing set. Repeat
+# Finally, make predictions with both models on this new ranging set. Repeat
 # the plotting of the previous exercise.
 
 # %%
 # solution
-target_predicted_linear_regression = linear_regression.predict(data_test)
-target_predicted_tree = tree.predict(data_test)
+target_predicted_linear_regression = linear_regression.predict(data_range)
+target_predicted_tree = tree.predict(data_range)
 
 # %% tags=["solution"]
 sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted_linear_regression,
+plt.plot(data_range, target_predicted_linear_regression,
          label="Linear regression")
-plt.plot(data_test, target_predicted_tree, label="Decision tree")
+plt.plot(data_range, target_predicted_tree, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction of linear model and a decision tree")
 


### PR DESCRIPTION
closes #442 

In some notebooks the word "test" is used for denoting data generated in equally-spaced intervals for the visual evaluation of the
predictions, given that such data was not seen during training. This could be confusing with the notion of "test" as a subset of the data coming from either a train-test split or cross-validation.
I changed  `data_test` to `data_range` whenever the former meaning was intended. The notation was chosen to match with [this notebook](https://inria.github.io/scikit-learn-mooc/python_scripts/ensemble_sol_02.html), where we use the term `data_ranges` instead of `data_test`. I also edited the rest of the text accordingly and added a warning when _both_ meanings were intended in the same notebook.