### PR TITLE
Add explanation of dates relation to age

### DIFF
--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -55,10 +55,10 @@ categorical_columns = categorical_columns_selector(data)
 # ```{caution}
 # Here, we know that `object` data type is used to represent strings and thus
 # categorical features. Be aware that this is not always the case. Sometimes
-# `object` data type could contain other type of information, such as dates that
-# were not parsed and can then relate to age (a quantity). In a more general
-# scenario you should manually introspect the content of your dataframe not to
-# wrongly use `make_column_selector`.
+# `object` data type could contain other types of information, such as dates that
+# were not properly formated (strings) and yet can relate to age (a quantity).
+# In a more general scenario you should manually introspect the content of your
+# dataframe not to wrongly use `make_column_selector`.
 # ```
 
 # %% [markdown]

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -56,7 +56,9 @@ categorical_columns = categorical_columns_selector(data)
 # Here, we know that `object` data type is used to represent strings and thus
 # categorical features. Be aware that this is not always the case. Sometimes
 # `object` data type could contain other types of information, such as dates that
-# were not properly formated (strings) and yet can relate to age (a quantity).
+# were not properly formatted (strings) and yet relate to a quantity of
+# elapsed  time.
+#
 # In a more general scenario you should manually introspect the content of your
 # dataframe not to wrongly use `make_column_selector`.
 # ```

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -55,9 +55,10 @@ categorical_columns = categorical_columns_selector(data)
 # ```{caution}
 # Here, we know that `object` data type is used to represent strings and thus
 # categorical features. Be aware that this is not always the case. Sometimes
-# `object` data type could contain other type of information (e.g. dates that
-# were not parsed) and you should manually introspect the content of your
-# dataframe to not wrongly use `make_column_selector`.
+# `object` data type could contain other type of information, such as dates that
+# were not parsed and can then relate to age (a quantity). In a more general
+# scenario you should manually introspect the content of your dataframe not to
+# wrongly use `make_column_selector`.
 # ```
 
 # %% [markdown]


### PR DESCRIPTION
Wrap-up M1 Q4 has a score of 61.4% This shows that dates can easily be confused with an ordinal category. 
This PR adds an explanation on how date and age are related.