### PR TITLE
MNT Remove `enable_hist_gradient_boosting`

### DIFF
--- a/jupyter-book/ensemble/ensemble_wrap_up_quiz.md
+++ b/jupyter-book/ensemble/ensemble_wrap_up_quiz.md
@@ -99,16 +99,6 @@ Evaluate the performance of a
 `sklearn.ensemble.HistGradientBoostingClassifier`. Enable early-stopping and
 add as many trees as needed.
 
-**Note**: Be aware that you need a specific import when importing the
-`HistGradientBoostingClassifier`:
-
-```python
-# explicitly require this experimental feature
-from sklearn.experimental import enable_hist_gradient_boosting
-# now you can import normally from ensemble
-from sklearn.ensemble import HistGradientBoostingClassifier
-```
-
 ```{admonition} Question
 Is histogram gradient boosting a better classifier considering the mean of
 the cross-validation test score?

--- a/notebooks/03_categorical_pipeline_column_transformer.ipynb
+++ b/notebooks/03_categorical_pipeline_column_transformer.ipynb
@@ -367,7 +367,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",

--- a/notebooks/03_categorical_pipeline_ex_02.ipynb
+++ b/notebooks/03_categorical_pipeline_ex_02.ipynb
@@ -84,7 +84,6 @@
     "from sklearn.pipeline import make_pipeline\n",
     "from sklearn.compose import ColumnTransformer\n",
     "from sklearn.preprocessing import OrdinalEncoder\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "\n",
     "categorical_preprocessor = OrdinalEncoder(handle_unknown=\"use_encoded_value\",\n",

--- a/notebooks/03_categorical_pipeline_sol_02.ipynb
+++ b/notebooks/03_categorical_pipeline_sol_02.ipynb
@@ -84,7 +84,6 @@
     "from sklearn.pipeline import make_pipeline\n",
     "from sklearn.compose import ColumnTransformer\n",
     "from sklearn.preprocessing import OrdinalEncoder\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "\n",
     "categorical_preprocessor = OrdinalEncoder(handle_unknown=\"use_encoded_value\",\n",

--- a/notebooks/ensemble_hist_gradient_boosting.ipynb
+++ b/notebooks/ensemble_hist_gradient_boosting.ipynb
@@ -209,7 +209,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingRegressor\n",
     "\n",
     "histogram_gradient_boosting = HistGradientBoostingRegressor(\n",

--- a/notebooks/ensemble_sol_05.ipynb
+++ b/notebooks/ensemble_sol_05.ipynb
@@ -41,7 +41,6 @@
    "outputs": [],
    "source": [
     "# solution\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingRegressor\n",
     "\n",
     "hist_gbdt = HistGradientBoostingRegressor(\n",

--- a/notebooks/parameter_tuning_ex_02.ipynb
+++ b/notebooks/parameter_tuning_ex_02.ipynb
@@ -52,8 +52,6 @@
     "      selector(dtype_include=object))],\n",
     "    remainder='passthrough', sparse_threshold=0)\n",
     "\n",
-    "# This line is currently required to import HistGradientBoostingClassifier\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "from sklearn.pipeline import Pipeline\n",
     "\n",

--- a/notebooks/parameter_tuning_grid_search.ipynb
+++ b/notebooks/parameter_tuning_grid_search.ipynb
@@ -182,8 +182,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for the moment this line is required to import HistGradientBoostingClassifier\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "from sklearn.pipeline import Pipeline\n",
     "\n",

--- a/notebooks/parameter_tuning_nested.ipynb
+++ b/notebooks/parameter_tuning_nested.ipynb
@@ -114,8 +114,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for the moment this line is required to import HistGradientBoostingClassifier\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "from sklearn.pipeline import Pipeline\n",
     "\n",

--- a/notebooks/parameter_tuning_randomized_search.ipynb
+++ b/notebooks/parameter_tuning_randomized_search.ipynb
@@ -138,8 +138,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for the moment this line is required to import HistGradientBoostingClassifier\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "from sklearn.pipeline import Pipeline\n",
     "\n",

--- a/notebooks/parameter_tuning_sol_02.ipynb
+++ b/notebooks/parameter_tuning_sol_02.ipynb
@@ -52,8 +52,6 @@
     "      selector(dtype_include=object))],\n",
     "    remainder='passthrough', sparse_threshold=0)\n",
     "\n",
-    "# This line is currently required to import HistGradientBoostingClassifier\n",
-    "from sklearn.experimental import enable_hist_gradient_boosting\n",
     "from sklearn.ensemble import HistGradientBoostingClassifier\n",
     "from sklearn.pipeline import Pipeline\n",
     "\n",

--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -232,7 +232,6 @@ print("The mean cross-validation accuracy is: "
 # is slightly simpler than the one we saw earlier for the `LogisticRegression`:
 
 # %%
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.preprocessing import OrdinalEncoder
 

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -62,7 +62,6 @@ from sklearn.model_selection import cross_validate
 from sklearn.pipeline import make_pipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OrdinalEncoder
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 
 categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -62,7 +62,6 @@ from sklearn.model_selection import cross_validate
 from sklearn.pipeline import make_pipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OrdinalEncoder
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 
 categorical_preprocessor = OrdinalEncoder(handle_unknown="use_encoded_value",

--- a/python_scripts/ensemble_hist_gradient_boosting.py
+++ b/python_scripts/ensemble_hist_gradient_boosting.py
@@ -130,7 +130,6 @@ print(f"Average score time: "
 # computation times with the experiment of the previous section.
 
 # %%
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 histogram_gradient_boosting = HistGradientBoostingRegressor(

--- a/python_scripts/ensemble_sol_05.py
+++ b/python_scripts/ensemble_sol_05.py
@@ -20,7 +20,6 @@ target *= 100  # rescale the target in k$
 
 # %%
 # solution
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 hist_gbdt = HistGradientBoostingRegressor(

--- a/python_scripts/parameter_tuning_ex_02.py
+++ b/python_scripts/parameter_tuning_ex_02.py
@@ -50,8 +50,6 @@ preprocessor = ColumnTransformer(
       selector(dtype_include=object))],
     remainder='passthrough', sparse_threshold=0)
 
-# This line is currently required to import HistGradientBoostingClassifier
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.pipeline import Pipeline
 

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -91,8 +91,6 @@ preprocessor = ColumnTransformer([
 # predict whether or not a person earns more than 50 k$ a year.
 
 # %%
-# for the moment this line is required to import HistGradientBoostingClassifier
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.pipeline import Pipeline
 

--- a/python_scripts/parameter_tuning_nested.py
+++ b/python_scripts/parameter_tuning_nested.py
@@ -57,8 +57,6 @@ preprocessor = ColumnTransformer([
     remainder='passthrough', sparse_threshold=0)
 
 # %%
-# for the moment this line is required to import HistGradientBoostingClassifier
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.pipeline import Pipeline
 

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -71,8 +71,6 @@ preprocessor = ColumnTransformer([
     remainder='passthrough', sparse_threshold=0)
 
 # %%
-# for the moment this line is required to import HistGradientBoostingClassifier
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.pipeline import Pipeline
 

--- a/python_scripts/parameter_tuning_sol_02.py
+++ b/python_scripts/parameter_tuning_sol_02.py
@@ -49,8 +49,6 @@ preprocessor = ColumnTransformer(
       selector(dtype_include=object))],
     remainder='passthrough', sparse_threshold=0)
 
-# This line is currently required to import HistGradientBoostingClassifier
-from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.pipeline import Pipeline
 


### PR DESCRIPTION
Fixes #475. Removes `enable_hist_gradient_boosting` since this import is no longer necessary for scikit-learn >= 1.

I am making the corresponding MR in gitlab for the quiz.