### PR TITLE
MNT Fix or explain remaining warnings

### DIFF
--- a/python_scripts/datasets_bike_rides.py
+++ b/python_scripts/datasets_bike_rides.py
@@ -178,10 +178,16 @@ rng = np.random.RandomState(0)
 indices = rng.choice(np.arange(cycling_ride.shape[0]), size=500, replace=False)
 
 # %%
+import warnings
+
 subset = cycling_ride.iloc[indices]
 # Quantize the target and keep the midpoint for each interval
-subset["power"] = pd.qcut(subset["power"], 6, retbins=False)
-subset["power"] = subset["power"].apply(lambda x: x.mid)
+with warnings.catch_warnings():
+    # call that will ignore the warning messages
+    warnings.filterwarnings('ignore')
+
+    subset["power"] = pd.qcut(subset["power"], 6, retbins=False)
+    subset["power"] = subset["power"].apply(lambda x: x.mid)
 
 # %%
 import seaborn as sns

--- a/python_scripts/datasets_bike_rides.py
+++ b/python_scripts/datasets_bike_rides.py
@@ -178,16 +178,10 @@ rng = np.random.RandomState(0)
 indices = rng.choice(np.arange(cycling_ride.shape[0]), size=500, replace=False)
 
 # %%
-import warnings
-
-subset = cycling_ride.iloc[indices]
+subset = cycling_ride.iloc[indices].copy()
 # Quantize the target and keep the midpoint for each interval
-with warnings.catch_warnings():
-    # call that will ignore the warning messages
-    warnings.filterwarnings('ignore')
-
-    subset["power"] = pd.qcut(subset["power"], 6, retbins=False)
-    subset["power"] = subset["power"].apply(lambda x: x.mid)
+subset["power"] = pd.qcut(subset["power"], 6, retbins=False)
+subset["power"] = subset["power"].apply(lambda x: x.mid)
 
 # %%
 import seaborn as sns

--- a/python_scripts/datasets_bike_rides.py
+++ b/python_scripts/datasets_bike_rides.py
@@ -132,8 +132,8 @@ data.index.normalize().nunique()
 
 # %%
 date_first_ride = "2020-08-18"
-cycling_ride = cycling[date_first_ride]
-data_ride, target_ride = data[date_first_ride], target[date_first_ride]
+cycling_ride = cycling.loc[date_first_ride]
+data_ride, target_ride = data.loc[date_first_ride], target.loc[date_first_ride]
 
 # %%
 data_ride.plot()

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -257,11 +257,17 @@ _ = plt.title("Predictions from a bagging classifier")
 # Let us compare the based model predictions with their average:
 
 # %%
-for tree_idx, tree in enumerate(bagged_trees.estimators_):
-    label = "Predictions of individual trees" if tree_idx == 0 else None
-    tree_predictions = tree.predict(data_test)
-    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.1,
-             color="tab:blue", label=label)
+import warnings
+
+with warnings.catch_warnings():
+    # call that will ignore the warning messages
+    warnings.filterwarnings('ignore', category=UserWarning)
+
+    for tree_idx, tree in enumerate(bagged_trees.estimators_):
+        label = "Predictions of individual trees" if tree_idx == 0 else None
+        tree_predictions = tree.predict(data_test)
+        plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.1,
+                 color="tab:blue", label=label)
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -260,8 +260,11 @@ _ = plt.title("Predictions from a bagging classifier")
 import warnings
 
 with warnings.catch_warnings():
-    # call that will ignore the warning messages
-    warnings.filterwarnings('ignore', category=UserWarning)
+    # ignore scikit-learn warning when accesing bagged estimators
+    warnings.filterwarnings(
+        "ignore",
+        message="X has feature names, but DecisionTreeRegressor was fitted without feature names",
+    )
 
     for tree_idx, tree in enumerate(bagged_trees.estimators_):
         label = "Predictions of individual trees" if tree_idx == 0 else None

--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -134,7 +134,7 @@ cv_results = cross_validate(ridge, data, target,
 # %% [markdown]
 # The code cell above will generate a couple of warnings because the features
 # included both extremely large and extremely small values, which are causing
-# problems with the underlying linear algebra solver used to fit the model.
+# numerical problems when training the predictive model.
 #
 # We can explore the train and test scores of this model.
 

--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -163,7 +163,7 @@ _ = plt.title("Ridge weights")
 
 # %% [markdown]
 # By comparing the magnitude of the weights on this plot compared to the
-# previous plot, we see that the magnitude of the weights are shrunk towards
+# previous plot, we see that the magnitude of the weights is shrunk towards
 # zero in comparison with the linear regression model.
 #
 # However, in this example, we omitted two important aspects: (i) the need to

--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -131,6 +131,13 @@ cv_results = cross_validate(ridge, data, target,
                             return_train_score=True,
                             return_estimator=True)
 
+# %% [markdown]
+# The code cell above will generate a couple of warnings because the features
+# included both extremely large and extremely small values, which are causing
+# problems with the underlying linear algebra solver used to fit the model.
+#
+# We can explore the train and test scores of this model.
+
 # %%
 train_error = -cv_results["train_score"]
 print(f"Mean squared error of linear regression model on the train set:\n"


### PR DESCRIPTION
The reason is that we will still have some remaining warnings that are not addressed in #484.

- The `UserWarning` in [ensemble_bagging](https://inria.github.io/scikit-learn-mooc/python_scripts/ensemble_bagging.html) could be fixed by addressing [#21599](https://github.com/scikit-learn/scikit-learn/issues/21599). In this PR I simply use a `warnings.filterwarnings`.
- The `UserWarning` in [ensemble_sol_02](https://inria.github.io/scikit-learn-mooc/python_scripts/ensemble_sol_02.html) may be fixed by [#21578](https://github.com/scikit-learn/scikit-learn/pull/21578).
- The `FutureWarning` in [datasets_bike_rides](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_bike_rides.html) is fixed by updating `datetimelike` index notation.
- The `SettingWithCopyWarning` in [datasets_bike_rides](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_bike_rides.html) is fixed ~~with a `warnings.filterwarnings`~~ by creating an explicit copy of the dataframe.
- A short paragraph is added to explain the `LinAlgWarning` in [linear_models_regularization](https://inria.github.io/scikit-learn-mooc/python_scripts/linear_models_regularization.html).