### PR TITLE
ENH Add python code for notebook used in the `Pipeline` video

### DIFF
--- a/jupyter-book/_toc.yml
+++ b/jupyter-book/_toc.yml
@@ -34,6 +34,7 @@ parts:
     - file: python_scripts/03_categorical_pipeline_column_transformer
     - file: python_scripts/03_categorical_pipeline_ex_02
     - file: python_scripts/03_categorical_pipeline_sol_02
+    - file: predictive_modeling_pipeline/03_categorical_pipeline_video
     - file: predictive_modeling_pipeline/03_categorical_pipeline_quiz_m1_03
   - file: predictive_modeling_pipeline/wrap_up_quiz
   - file: predictive_modeling_pipeline/predictive_modeling_module_take_away

--- a/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
+++ b/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
@@ -1,3 +1,3 @@
 # 🎥 How to define a scikit-learn pipeline and visualize it
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5ri7BhFrNe4" title="YouTube video player" frameborder="0" rel="0" showinfo="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/5ri7BhFrNe4?rel=0" title="YouTube video player" frameborder="0" rel="0" showinfo="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
+++ b/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
@@ -1,0 +1,1 @@
+# 🎥 How to define a scikit-learn pipeline and visualize it

--- a/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
+++ b/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
@@ -1,3 +1,5 @@
 # 🎥 How to define a scikit-learn pipeline and visualize it
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5ri7BhFrNe4?rel=0" title="YouTube video player" frameborder="0" rel="0" showinfo="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div class="video_player">
+<iframe width="640" height="480" src="https://www.youtube.com/embed/5ri7BhFrNe4?rel=0" title="YouTube video player" frameborder="0" rel="0" showinfo="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>

--- a/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
+++ b/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
@@ -1,1 +1,3 @@
 # 🎥 How to define a scikit-learn pipeline and visualize it
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/5ri7BhFrNe4" title="YouTube video player" frameborder="0" rel="0" showinfo="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/python_scripts/video_pipeline.py
+++ b/python_scripts/video_pipeline.py
@@ -1,0 +1,91 @@
+# %% [markdown]
+# # How to define a scikit-learn pipeline and visualize it
+
+# %% [markdown]
+# ### First we load the dataset
+
+# %% [markdown]
+# We need to define our data and target. In this case we will build a classification model
+
+# %%
+import pandas as pd
+
+ames_housing = pd.read_csv("../datasets/house_prices.csv", na_values='?')
+
+target_name = "SalePrice"
+data, target = ames_housing.drop(columns=target_name), ames_housing[target_name]
+target = (target > 200_000).astype(int)
+
+# %% [markdown]
+# We inspect the "head" of the dataframe
+
+# %%
+data.head()
+
+# %% [markdown]
+# We can cherry-pick some features and only retain this subset of data
+
+# %%
+numeric_features = ['LotArea', 'FullBath', 'HalfBath']
+categorical_features = ['Neighborhood','HouseStyle']
+data = data[numeric_features + categorical_features]
+
+# %% [markdown]
+# ### Then we create the pipeline
+
+# %% [markdown]
+# The first step is to define the preprocessing steps
+
+# %%
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+
+numeric_transformer = Pipeline(steps=[
+    ('imputer', SimpleImputer(strategy='median')),
+    ('scaler', StandardScaler(),
+)])
+
+categorical_transformer = OneHotEncoder(handle_unknown='ignore')
+
+# %% [markdown]
+# The next step is to apply the transformations using `ColumnTransformer`
+
+# %%
+from sklearn.compose import ColumnTransformer
+
+preprocessor = ColumnTransformer(transformers=[
+    ('num', numeric_transformer, numeric_features),
+    ('cat', categorical_transformer, categorical_features),
+])
+
+# %% [markdown]
+# Then we define the model and join the steps in order
+
+# %%
+from sklearn.linear_model import LogisticRegression
+
+model = Pipeline(steps=[
+    ('preprocessor', preprocessor),
+    ('classifier', LogisticRegression()),
+])
+
+# %% [markdown]
+# Let's visualize it!
+
+# %%
+from sklearn import set_config
+
+set_config(display='diagram')
+model
+
+# %% [markdown]
+# ### Finally we score the model
+
+# %%
+from sklearn.model_selection import cross_validate
+
+cv_results = cross_validate(model, data, target, cv=5)
+scores = cv_results["test_score"]
+print("The mean cross-validation accuracy is: "
+      f"{scores.mean():.3f} +/- {scores.std():.3f}")

--- a/python_scripts/video_pipeline.py
+++ b/python_scripts/video_pipeline.py
@@ -2,6 +2,13 @@
 # # How to define a scikit-learn pipeline and visualize it
 
 # %% [markdown]
+# The goal of keeping this notebook is to:
+
+# - make it available for users that want to reproduce it locally
+# - archive the script in the event we want to rerecord this video with an
+#   update in the UI of scikit-learn in a future release.
+
+# %% [markdown]
 # ### First we load the dataset
 
 # %% [markdown]


### PR DESCRIPTION
Fixes #465.

I think the best place for the video would be somewhere between [Exercise M1.05](https://inria.github.io/scikit-learn-mooc/python_scripts/03_categorical_pipeline_sol_02.html) and the first wrap-up quiz.

The idea is that the video and notebook will be displayed simultaneously within a split webpage. This may require FUN changes.