### PR TITLE
MNT Improve consistency of definitions

### DIFF
--- a/python_scripts/ensemble_ex_02.py
+++ b/python_scripts/ensemble_ex_02.py
@@ -12,9 +12,9 @@ import pandas as pd
 from sklearn.model_selection import train_test_split
 
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
-feature_names = ["Flipper Length (mm)"]
+feature_name = "Flipper Length (mm)"
 target_name = "Body Mass (g)"
-data, target = penguins[feature_names], penguins[target_name]
+data, target = penguins[[feature_name]], penguins[target_name]
 data_train, data_test, target_train, target_test = train_test_split(
     data, target, random_state=0)
 

--- a/python_scripts/ensemble_sol_02.py
+++ b/python_scripts/ensemble_sol_02.py
@@ -11,9 +11,9 @@ import pandas as pd
 from sklearn.model_selection import train_test_split
 
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
-feature_names = ["Flipper Length (mm)"]
+feature_name = "Flipper Length (mm)"
 target_name = "Body Mass (g)"
-data, target = penguins[feature_names], penguins[target_name]
+data, target = penguins[[feature_name]], penguins[target_name]
 data_train, data_test, target_train, target_test = train_test_split(
     data, target, random_state=0)
 
@@ -77,7 +77,7 @@ forest_predictions = forest.predict(data_range)
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sns.scatterplot(data=penguins, x=feature_names[0], y=target_name,
+sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
 
 # plot tree predictions

--- a/python_scripts/linear_regression_in_sklearn.py
+++ b/python_scripts/linear_regression_in_sklearn.py
@@ -22,9 +22,9 @@
 import pandas as pd
 
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
-feature_names = "Flipper Length (mm)"
+feature_name = "Flipper Length (mm)"
 target_name = "Body Mass (g)"
-data, target = penguins[[feature_names]], penguins[target_name]
+data, target = penguins[[feature_name]], penguins[target_name]
 
 # %% [markdown]
 # ```{note}
@@ -66,7 +66,7 @@ predicted_body_mass = (
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sns.scatterplot(x=data[feature_names], y=target, color="black", alpha=0.5)
+sns.scatterplot(x=data[feature_name], y=target, color="black", alpha=0.5)
 plt.plot(flipper_length_range, predicted_body_mass)
 _ = plt.title("Model using LinearRegression from scikit-learn")
 

--- a/python_scripts/linear_regression_without_sklearn.py
+++ b/python_scripts/linear_regression_without_sklearn.py
@@ -24,11 +24,11 @@ penguins.head()
 # %%
 import seaborn as sns
 
-feature_names = "Flipper Length (mm)"
+feature_name = "Flipper Length (mm)"
 target_name = "Body Mass (g)"
-data, target = penguins[[feature_names]], penguins[target_name]
+data, target = penguins[[feature_name]], penguins[target_name]
 
-ax = sns.scatterplot(data=penguins, x=feature_names, y=target_name,
+ax = sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                      color="black", alpha=0.5)
 ax.set_title("Flipper length in function of the body mass")
 
@@ -83,7 +83,7 @@ predicted_body_mass = linear_model_flipper_mass(
 # %%
 label = "{0:.2f} (g / mm) * flipper length + {1:.2f} (g)"
 
-ax = sns.scatterplot(data=penguins, x=feature_names, y=target_name,
+ax = sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                      color="black", alpha=0.5)
 ax.plot(flipper_length_range, predicted_body_mass)
 _ = ax.set_title(label.format(weight_flipper_length, intercept_body_mass))
@@ -109,7 +109,7 @@ predicted_body_mass = linear_model_flipper_mass(
 # We can now plot all samples and the linear model prediction.
 
 # %%
-ax = sns.scatterplot(data=penguins, x=feature_names, y=target_name,
+ax = sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                      color="black", alpha=0.5)
 ax.plot(flipper_length_range, predicted_body_mass)
 _ = ax.set_title(label.format(weight_flipper_length, intercept_body_mass))
@@ -148,7 +148,7 @@ predicted_body_mass = linear_model_flipper_mass(
     flipper_length_range, weight_flipper_length, intercept_body_mass)
 
 # %%
-ax = sns.scatterplot(data=penguins, x=feature_names, y=target_name,
+ax = sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                      color="black", alpha=0.5)
 ax.plot(flipper_length_range, predicted_body_mass)
 _ = ax.set_title(label.format(weight_flipper_length, intercept_body_mass))
@@ -164,7 +164,7 @@ predicted_body_mass = linear_model_flipper_mass(
     flipper_length_range, weight_flipper_length, intercept_body_mass)
 
 # %%
-ax = sns.scatterplot(data=penguins, x=feature_names, y=target_name,
+ax = sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                      color="black", alpha=0.5)
 ax.plot(flipper_length_range, predicted_body_mass)
 _ = ax.set_title(label.format(weight_flipper_length, intercept_body_mass))

--- a/python_scripts/trees_dataset.py
+++ b/python_scripts/trees_dataset.py
@@ -74,11 +74,11 @@ pairplot_figure.fig.set_size_inches(9, 6.5)
 # %%
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
 
-data_columns = ["Flipper Length (mm)"]
+feature_name = "Flipper Length (mm)"
 target_column = "Body Mass (g)"
 
 # %%
-_ = sns.scatterplot(data=penguins, x=data_columns[0], y=target_column)
+_ = sns.scatterplot(data=penguins, x=feature_name, y=target_column)
 
 # %% [markdown]
 # Here, we deal with a regression problem because our target is a continuous

--- a/python_scripts/trees_ex_02.py
+++ b/python_scripts/trees_ex_02.py
@@ -15,10 +15,9 @@ import pandas as pd
 
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
 
-data_columns = ["Flipper Length (mm)"]
-target_column = "Body Mass (g)"
-
-data_train, target_train = penguins[data_columns], penguins[target_column]
+feature_name = "Flipper Length (mm)"
+target_name = "Body Mass (g)"
+data_train, target_train = penguins[[feature_name]], penguins[target_name]
 
 # %% [markdown]
 # ```{note}

--- a/python_scripts/trees_regression.py
+++ b/python_scripts/trees_regression.py
@@ -19,10 +19,9 @@ import pandas as pd
 
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
 
-data_columns = ["Flipper Length (mm)"]
-target_column = "Body Mass (g)"
-
-data_train, target_train = penguins[data_columns], penguins[target_column]
+feature_name = "Flipper Length (mm)"
+target_name = "Body Mass (g)"
+data_train, target_train = penguins[[feature_name]], penguins[target_name]
 
 # %% [markdown]
 # To illustrate how decision trees are predicting in a regression setting, we
@@ -32,9 +31,9 @@ data_train, target_train = penguins[data_columns], penguins[target_column]
 # %%
 import numpy as np
 
-data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
-                                   data_train[data_columns[0]].max()),
-                         columns=data_columns)
+data_test = pd.DataFrame(np.arange(data_train[feature_name].min(),
+                                   data_train[feature_name].max()),
+                                   columns=[feature_name])
 
 # %% [markdown]
 # Using the term "test" here refers to data that was not used for training.
@@ -54,7 +53,7 @@ data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
+sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
 _ = plt.title("Illustration of the regression dataset used")
 
@@ -70,7 +69,7 @@ linear_model.fit(data_train, target_train)
 target_predicted = linear_model.predict(data_test)
 
 # %%
-sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
+sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
 plt.plot(data_test, target_predicted, label="Linear regression")
 plt.legend()
@@ -83,7 +82,7 @@ _ = plt.title("Prediction function using a LinearRegression")
 # will be on the line.
 
 # %%
-ax = sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
+ax = sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                      color="black", alpha=0.5)
 plt.plot(data_test, target_predicted, label="Linear regression",
          linestyle="--")
@@ -106,7 +105,7 @@ tree.fit(data_train, target_train)
 target_predicted = tree.predict(data_test)
 
 # %%
-sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
+sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
 plt.plot(data_test, target_predicted, label="Decision tree")
 plt.legend()
@@ -125,7 +124,7 @@ _ = plt.title("Prediction function using a DecisionTreeRegressor")
 from sklearn.tree import plot_tree
 
 _, ax = plt.subplots(figsize=(8, 6))
-_ = plot_tree(tree, feature_names=data_columns, ax=ax)
+_ = plot_tree(tree, feature_names=feature_name, ax=ax)
 
 # %% [markdown]
 # The threshold for our feature (flipper length) is 206.5 mm. The predicted
@@ -143,7 +142,7 @@ tree.fit(data_train, target_train)
 target_predicted = tree.predict(data_test)
 
 # %%
-sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
+sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
 plt.plot(data_test, target_predicted, label="Decision tree")
 plt.legend()

--- a/python_scripts/trees_sol_02.py
+++ b/python_scripts/trees_sol_02.py
@@ -14,10 +14,9 @@ import pandas as pd
 
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
 
-data_columns = ["Flipper Length (mm)"]
-target_column = "Body Mass (g)"
-
-data_train, target_train = penguins[data_columns], penguins[target_column]
+feature_name = "Flipper Length (mm)"
+target_name = "Body Mass (g)"
+data_train, target_train = penguins[[feature_name]], penguins[target_name]
 
 # %% [markdown]
 # ```{note}
@@ -50,9 +49,9 @@ tree.fit(data_train, target_train)
 # solution
 import numpy as np
 
-data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min(),
-                                   data_train[data_columns[0]].max()),
-                         columns=data_columns)
+data_test = pd.DataFrame(np.arange(data_train[feature_name].min(),
+                                   data_train[feature_name].max()),
+                         columns=[feature_name])
 
 # %% tags=["solution"]
 target_predicted_linear_regression = linear_regression.predict(data_test)
@@ -67,7 +66,7 @@ target_predicted_tree = tree.predict(data_test)
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
+sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
 plt.plot(data_test, target_predicted_linear_regression,
          label="Linear regression")
@@ -89,9 +88,9 @@ _ = plt.title("Prediction of linear model and a decision tree")
 # %%
 # solution
 offset = 30
-data_test = pd.DataFrame(np.arange(data_train[data_columns[0]].min() - offset,
-                                   data_train[data_columns[0]].max() + offset),
-                         columns=data_columns)
+data_test = pd.DataFrame(np.arange(data_train[feature_name].min() - offset,
+                                   data_train[feature_name].max() + offset),
+                         columns=[feature_name])
 
 # %% [markdown]
 # Finally, make predictions with both models on this new interval of data.
@@ -103,7 +102,7 @@ target_predicted_linear_regression = linear_regression.predict(data_test)
 target_predicted_tree = tree.predict(data_test)
 
 # %% tags=["solution"]
-sns.scatterplot(data=penguins, x="Flipper Length (mm)", y="Body Mass (g)",
+sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
 plt.plot(data_test, target_predicted_linear_regression,
          label="Linear regression")


### PR DESCRIPTION
The [first exercise on linear models](linear_models_sol_01.py) uses the notation in singular `feature_name = "Flipper Length (mm)"` but some other notebooks define the variable in plural (i.e. `feature_names = "Flipper Length (mm)"`) even if there is one feature only. This PR solves this small detail and looks for consistency in notation across these notebooks.