### PR TITLE
Remove permutation test score

### DIFF
--- a/python_scripts/cross_validation_baseline.py
+++ b/python_scripts/cross_validation_baseline.py
@@ -1,23 +1,22 @@
 # %% [markdown]
 # # Comparing results with baseline and chance level
 #
-# In this notebook, we present how to compare the generalization performance of a
-# model to a minimal baseline.
+# In this notebook, we present how to compare the generalization performance of
+# a model to a minimal baseline.
 #
-# Indeed, in the previous notebook, we compared the testing error by
-# taking into account the target distribution. A good practice is to compare
-# the testing error with a dummy baseline and the chance level. In
-# regression, we could use the `DummyRegressor` and predict the mean target
-# without using the data. The chance level can be determined by permuting the
-# labels and check the difference of result.
+# Indeed, in the previous notebook, we compared the testing error by taking
+# into account the target distribution. A good practice is to compare the
+# testing error with a dummy baseline to define a chance level. In regression,
+# we could use the `DummyRegressor` and predict the mean target value observed
+# on the training set without using the input features.
 #
-# Therefore, we will conduct experiment to get the score of a model and the two
-# baselines. We will start by loading the California housing dataset.
+# This notebook demonstrates how to compute the the score of a regression model
+# and the baseline on the California housing dataset.
 
 # %% [markdown]
 # ```{note}
 # If you want a deeper overview regarding this dataset, you can refer to the
-# Appendix - Datasets description section at the end of this MOOC.
+# section named "Appendix - Datasets description" at the end of this MOOC.
 # ```
 
 # %%
@@ -27,7 +26,8 @@ data, target = fetch_california_housing(return_X_y=True, as_frame=True)
 target *= 100  # rescale the target in k$
 
 # %% [markdown]
-# Across all evaluations, we will use a `ShuffleSplit` cross-validation.
+# Across all evaluations, we will use a `ShuffleSplit` cross-validation
+# splitter with 20% of the data held on the validation side of the split.
 
 # %%
 from sklearn.model_selection import ShuffleSplit
@@ -35,9 +35,9 @@ from sklearn.model_selection import ShuffleSplit
 cv = ShuffleSplit(n_splits=30, test_size=0.2, random_state=0)
 
 # %% [markdown]
-# We will start by running the cross-validation for the decision tree
-# regressor which is our model of interest. Besides, we will store the
-# testing error in a pandas series.
+# We start by running the cross-validation for a simple decision tree regressor
+# which is our model of interest. Besides, we will store the testing error in a
+# pandas series to make it easier to plot the results.
 
 # %%
 import pandas as pd
@@ -45,65 +45,57 @@ from sklearn.tree import DecisionTreeRegressor
 from sklearn.model_selection import cross_validate
 
 regressor = DecisionTreeRegressor()
-result_regressor = cross_validate(regressor, data, target,
-                                  cv=cv, scoring="neg_mean_absolute_error",
-                                  n_jobs=2)
+cv_results_tree_regressor = cross_validate(
+    regressor, data, target, cv=cv, scoring="neg_mean_absolute_error", n_jobs=2
+)
 
-errors_regressor = pd.Series(-result_regressor["test_score"],
-                             name="Regressor error")
+errors_tree_regressor = pd.Series(
+    -cv_results_tree_regressor["test_score"], name="Decision tree regressor"
+)
 
 # %% [markdown]
-# Then, we will evaluate our first baseline. This baseline is called a dummy
-# regressor. This dummy regressor will always predict the mean target computed
-# on the training. Therefore, the dummy regressor will never use any
-# information regarding the data `data`.
+# Then, we evaluate our baseline. This baseline is called a dummy regressor.
+# This dummy regressor will always predict the mean target computed on the
+# training target variable. Therefore, the dummy regressor does not use any
+# information from the input features stored in the dataframe named `data`.
 
 # %%
 from sklearn.dummy import DummyRegressor
 
-dummy = DummyRegressor()
-result_dummy = cross_validate(dummy, data, target,
-                              cv=cv, scoring="neg_mean_absolute_error",
-                              n_jobs=2)
-errors_dummy = pd.Series(-result_dummy["test_score"], name="Dummy error")
+dummy = DummyRegressor(strategy="mean")
+result_dummy = cross_validate(
+    dummy, data, target, cv=cv, scoring="neg_mean_absolute_error", n_jobs=2
+)
+errors_dummy_regressor = pd.Series(
+    -result_dummy["test_score"], name="Dummy regressor"
+)
+
 
 # %% [markdown]
-# Finally, we will evaluate the generalization performance of the second baseline.
-# This baseline will provide the generalization performance of the chance level.
-# Indeed, we will train a decision tree on some training data and evaluate the
-# same tree on data where the target vector has been randomized.
+# We now plot the testing errors for the mean target baseline and the actual
+# decision tree regressor.
 
 # %%
-from sklearn.model_selection import permutation_test_score
-
-regressor = DecisionTreeRegressor()
-score, permutation_score, pvalue = permutation_test_score(
-    regressor, data, target, cv=cv, scoring="neg_mean_absolute_error",
-    n_jobs=2, n_permutations=30)
-errors_permutation = pd.Series(-permutation_score, name="Permuted error")
-
-# %% [markdown]
-# Finally, we plot the testing errors for the two baselines and the
-# actual regressor.
-
-# %%
-final_errors = pd.concat([errors_regressor, errors_dummy, errors_permutation],
-                         axis=1)
+all_errors = pd.concat(
+    [errors_tree_regressor, errors_dummy_regressor],
+    axis=1,
+)
 
 # %%
 import matplotlib.pyplot as plt
 
-final_errors.plot.hist(bins=50, density=True, edgecolor="black")
+all_errors.plot.hist(bins=50, density=True, edgecolor="black")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 plt.xlabel("Mean absolute error (k$)")
 _ = plt.title("Distribution of the testing errors")
 
 # %% [markdown]
 # We see that even if the generalization performance of our model is far from
-# being good, it is better than the two baselines. Besides, we see that the
-# dummy regressor is better than a chance level regressor.
+# being perfect (price predictions are off by more than 25,000 US dollars on
+# average), it is much better than the mean price baseline.
 #
-# In practice, using a dummy regressor might be sufficient as a baseline.
-# Indeed, to obtain a reliable estimate the permutation of the target should
-# be repeated and thus this method is costly. However, it gives the true
-# chance level.
+# Note that here we used the mean price as the baseline prediction. We could
+# have used the median or an arbitrary constant instead. See the online
+# documentation of the
+# [sklearn.dummy.DummyRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyRegressor.html)
+# class for other options.

--- a/python_scripts/cross_validation_baseline.py
+++ b/python_scripts/cross_validation_baseline.py
@@ -2,16 +2,12 @@
 # # Comparing results with baseline and chance level
 #
 # In this notebook, we present how to compare the generalization performance of
-# a model to a minimal baseline.
+# a model to a minimal baseline. In regression, we can use the `DummyRegressor`
+# class to predict the mean target value observed on the training set without
+# using the input features.
 #
-# Indeed, in the previous notebook, we compared the testing error by taking
-# into account the target distribution. A good practice is to compare the
-# testing error with a dummy baseline to define a chance level. In regression,
-# we could use the `DummyRegressor` and predict the mean target value observed
-# on the training set without using the input features.
-#
-# This notebook demonstrates how to compute the the score of a regression model
-# and the baseline on the California housing dataset.
+# We now demonstrate how to compute the score of a regression model compare it
+# to such a baseline on the California housing dataset.
 
 # %% [markdown]
 # ```{note}
@@ -52,6 +48,7 @@ cv_results_tree_regressor = cross_validate(
 errors_tree_regressor = pd.Series(
     -cv_results_tree_regressor["test_score"], name="Decision tree regressor"
 )
+errors_tree_regressor.describe()
 
 # %% [markdown]
 # Then, we evaluate our baseline. This baseline is called a dummy regressor.
@@ -69,33 +66,43 @@ result_dummy = cross_validate(
 errors_dummy_regressor = pd.Series(
     -result_dummy["test_score"], name="Dummy regressor"
 )
+errors_dummy_regressor.describe()
 
 
 # %% [markdown]
-# We now plot the testing errors for the mean target baseline and the actual
-# decision tree regressor.
+# We now plot the cross-validation testing errors for the mean target baseline
+# and the actual decision tree regressor.
 
 # %%
 all_errors = pd.concat(
     [errors_tree_regressor, errors_dummy_regressor],
     axis=1,
 )
+all_errors
 
 # %%
 import matplotlib.pyplot as plt
+import numpy as np
 
-all_errors.plot.hist(bins=50, density=True, edgecolor="black")
+bins = np.linspace(start=0, stop=100, num=80)
+all_errors.plot.hist(bins=bins, density=True, edgecolor="black")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 plt.xlabel("Mean absolute error (k$)")
-_ = plt.title("Distribution of the testing errors")
+_ = plt.title("Cross-validation testing errors")
 
 # %% [markdown]
-# We see that even if the generalization performance of our model is far from
-# being perfect (price predictions are off by more than 25,000 US dollars on
-# average), it is much better than the mean price baseline.
+# We see that the generalization performance of our decision tree is far from
+# being perfect: the price predictions are off by more than 45,000 US dollars
+# on average. However it is much better than the mean price baseline. So this
+# confirms that it is possible to predict the housing price much better by
+# using a model that takes into account the values of the input features
+# (housing location, size, neighborhood income...). Such a model makes more
+# informed predictions and approximately divide the error rate by a factor of 2
+# compared to the baseline that ignores the input features.
 #
 # Note that here we used the mean price as the baseline prediction. We could
-# have used the median or an arbitrary constant instead. See the online
-# documentation of the
+# have used the median instead. See the online documentation of the
 # [sklearn.dummy.DummyRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyRegressor.html)
-# class for other options.
+# class for other options. For this particular example, using the mean instead
+# of the median does not make much of a difference but this could have been the
+# case for dataset with extreme outliers.

--- a/python_scripts/cross_validation_sol_02.py
+++ b/python_scripts/cross_validation_sol_02.py
@@ -1,9 +1,9 @@
 # %% [markdown]
 # # 📃 Solution for Exercise M7.01
 #
-# This notebook aims at building some baseline classifiers, which we use as
-# references to assess the relative predictive performance of a given model of
-# interest.
+# In this exercise we will define dummy classification baselines and use them
+# as reference to assess the relative predictive performance of a given model
+# of interest.
 #
 # We illustrate those baselines with the help of the Adult Census dataset,
 # using only the numerical features for the sake of simplicity.
@@ -16,7 +16,7 @@ data, target = adult_census.drop(columns="class"), adult_census["class"]
 
 # %% [markdown]
 # First, define a `ShuffleSplit` cross-validation strategy taking half of the
-# samples as a testing at each round.
+# samples as a testing at each round. Let us use 10 cross-validation rounds.
 
 # %%
 # solution
@@ -38,7 +38,7 @@ classifier = make_pipeline(StandardScaler(), LogisticRegression())
 
 # %% [markdown]
 # Compute the cross-validation (test) scores for the classifier on this
-# dataset. Keep the results in a numpy array or a pandas Series.
+# dataset. Store the results pandas Series as we did in the previous notebook.
 
 # %%
 # solution
@@ -51,7 +51,7 @@ cv_results_logistic_regression = cross_validate(
 test_score_logistic_regression = pd.Series(
     cv_results_logistic_regression["test_score"], name="Logistic Regression"
 )
-
+test_score_logistic_regression
 
 # %% [markdown]
 # Now, compute the cross-validation scores of a dummy classifier that
@@ -59,6 +59,8 @@ test_score_logistic_regression = pd.Series(
 # refer to the online documentation for the [sklearn.dummy.DummyClassifier
 # ](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyClassifier.html)
 # class.
+#
+# Store the results in a second pandas Series.
 
 # %%
 # solution
@@ -69,67 +71,93 @@ cv_results_most_frequent = cross_validate(
     most_frequent_classifier, data, target, cv=cv, n_jobs=2
 )
 test_score_most_frequent = pd.Series(
-    cv_results_most_frequent["test_score"],
-    name="Most frequent class predictor"
+    cv_results_most_frequent["test_score"], name="Most frequent class predictor"
 )
+test_score_most_frequent
 
 # %% [markdown]
-# Now that we collected the results from the baselines and the model, plot
-# the distributions of the different test scores.
-
-# %% [markdown]
-# We concatenate the different test score in the same pandas dataframe.
+# Now that we collected the results from the baseline and the model,
+# concatenate the test scores as columns a single pandas dataframe.
 
 # %%
 # solution
-final_test_scores = pd.concat(
+all_test_scores = pd.concat(
     [test_score_logistic_regression, test_score_most_frequent],
-    axis=1,
+    axis='columns',
 )
+all_test_scores
 
 # %% [markdown]
-# Next, plot the distributions of the test scores.
+#
+# Next, plot the an histogram of the cross-validation test scores for both
+# models with the help of [pandas built-in plotting
+# function](https://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html#histograms).
+#
+# What conclusions do you draw from the results?
 
 # %%
 # solution
+import numpy as np
 import matplotlib.pyplot as plt
 
-final_test_scores.plot.hist(bins=50, density=True, edgecolor="black")
+bins = np.linspace(start=0.5, stop=1.0, num=100)
+all_test_scores.plot.hist(bins=bins, density=True, edgecolor="black")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 plt.xlabel("Accuracy (%)")
-_ = plt.title("Distribution of the test scores")
+_ = plt.title("Distribution of the CV scores")
 
 # %% [markdown] tags=["solution"]
-# We observe that the dummy classifier with the strategy `most_frequent` is
-# equivalent to the permutation score. We can also conclude that our model
-# is better than the other baseline.
+# We observe that the two histograms are well separated. Therefore the dummy
+# classifier with the strategy `most_frequent` has significantly lower accuracy
+# than the logistic regression classifier. We conclude that the logistic
+# regression model can successfully find predictive information in the input
+# features to improve upon the baseline.
 
 # %% [markdown]
-# Change the strategy of the dummy classifier to `stratified`, compute the
-# results and plot the distribution together with the other results. Explain
-# why the results get worse.
+# Change the `strategy` of the dummy classifier to `"stratified"`, compute the
+# results. Similarly compute scores for `strategy="uniform"` and then the  plot
+# the distribution together with the other results.
+#
+# Are those new baselines better than the previous one? Why is this the case?
+#
+# # Please refer to the scikit-learn documentation on [sklearn.dummy.DummyClassifier
+# ](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyClassifier.html)
+# to find out about the meaning of the `"stratified"` and `"uniform"`
+# strategies.
 
 # %%
 # solution
-dummy = DummyClassifier(strategy="stratified")
-result_dummy_stratify = cross_validate(dummy, data, target, cv=cv, n_jobs=2)
-test_score_dummy_stratify = pd.Series(
-    result_dummy_stratify["test_score"], name="Dummy 'stratify' score"
+stratified_dummy = DummyClassifier(strategy="stratified")
+cv_results_stratified = cross_validate(
+    stratified_dummy, data, target, cv=cv, n_jobs=2
+)
+test_score_dummy_stratified = pd.Series(
+    cv_results_stratified["test_score"], name="Stratified class predictor"
+)
+
+# %%
+# solution
+uniform_dummy = DummyClassifier(strategy="uniform")
+cv_results_uniform = cross_validate(
+    uniform_dummy, data, target, cv=cv, n_jobs=2
+)
+test_score_dummy_uniform = pd.Series(
+    cv_results_uniform["test_score"], name="Uniform class predictor"
 )
 
 # %% tags=["solution"]
-final_test_scores = pd.concat(
+all_test_scores = pd.concat(
     [
-        test_score_classifier,
-        test_score_permutation,
-        test_score_dummy,
-        test_score_dummy_stratify,
+        test_score_logistic_regression,
+        test_score_most_frequent,
+        test_score_dummy_stratified,
+        test_score_dummy_uniform,
     ],
-    axis=1,
+    axis='columns',
 )
 
 # %% tags=["solution"]
-final_test_scores.plot.hist(bins=50, density=True, edgecolor="black")
+all_test_scores.plot.hist(bins=bins, density=True, edgecolor="black")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 plt.xlabel("Accuracy (%)")
 _ = plt.title("Distribution of the test scores")
@@ -143,28 +171,34 @@ _ = plt.title("Distribution of the test scores")
 # set's class distribution, resulting in some wrong predictions even for
 # the most frequent class, hence we obtain a lower accuracy.
 #
-# Please refer to the scikit-learn documentation on [sklearn.dummy.DummyClassifier
-# ](https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyClassifier.html)
-# for more details on the meaning of the `strategy="stratified"` parameter.
+# This is even more so for the `strategy="uniform"`: this strategy assigns
+# class labels uniformly at random. Therefore, on a binary classification
+# problem, the cross-validation accuracy is 50% on average, which is the
+# weakest of the three dummy baselines.
 
-# %% tags=["solution"]
-from sklearn.model_selection import cross_val_score
-
-dummy_models = {
-    "Dummy 'most_frequent'": DummyClassifier(strategy="most_frequent"),
-    "Dummy 'stratified'": DummyClassifier(strategy="stratified"),
-}
-n_runs = 3
-
-for run_idx in range(n_runs):
-    final_scores = pd.DataFrame(
-        {
-            f"{name} score": cross_val_score(model, data, target, cv=cv, n_jobs=2)
-            for name, model in dummy_models.items()
-        }
-    )
-
-    final_scores.plot.hist(bins=50, density=True, edgecolor="black")
-    plt.legend(bbox_to_anchor=(1.05, 0.8))
-    plt.xlabel("Accuracy (%)")
-    _ = plt.title(f"Distribution of scores in run #{run_idx}")
+# %% [markdown] tags=["solution"]
+# Note: one could argue that the `"uniform"` or `strategy="stratified"`
+# strategies are both valid ways to define a "chance level" baseline accuracy
+# for this classification problem, because they make predictions "by chance".
+#
+# Another way to define a chance level would be to use the
+# [sklearn.model_selection.permutation_test_score](https://scikit-learn.org/stable/auto_examples/model_selection/plot_permutation_tests_for_classification.html)
+# utility of scikit-learn. Instead of using a dummy classifier, this function
+# compares the cross-validation accuracy of a model of interest to the
+# cross-validation accuracy of this same model but trained on randomly permuted
+# class labels. The `permutation_test_score` therefore defines a chance level
+# that depends on the choice of the class and hyper-parameters of the estimator
+# of interest. When training on such randomly permuted labels, many machine
+# learning estimators would end up approximately behaving much like the
+# `DummyClassifier(strategy="most_frequent")` by always predicting the majority
+# class, irrespective of the input features. As a result, this
+# `"most_frequent"` baseline is sometimes called the "chance level" for
+# imbalanced classification problems, even though its predictions are
+# completely deterministic and do not involve much "chance" anymore.
+#
+# Defining the chance level using `permutation_test_score` is quite
+# computation-intensive because it requires fitting many non-dummy models on
+# random permutations of the data. Using dummy classifiers as baselines is
+# often enough for practical purposes. For imbalanced classification problems,
+# the `"most_frequent"` strategy is the strongest of the three baselines and
+# therefore the one we should use.


### PR DESCRIPTION
Address #449 to avoid using `permutation_test_score` to define chance level as it was found to be confusing and it's arguably just one way to define a chance level, not "the" way.

The quizz is being adapted accordingly in the private repo:

https://gitlab.inria.fr/learninglab/mooc-scikit-learn/mooc-scikit-learn-coordination/-/merge_requests/32

The exercise instructions and the quizz instructions will be synced in a follow-up commit once those 2 PRs are reviewed and merged.