### PR TITLE
Use score in tree hyperpatameter notebook

### DIFF
--- a/python_scripts/trees_hyperparameters.py
+++ b/python_scripts/trees_hyperparameters.py
@@ -114,13 +114,23 @@ tree_reg = DecisionTreeRegressor(max_depth=max_depth)
 # %%
 plot_classification(tree_clf, data_clf[data_clf_columns],
                     data_clf[target_clf_column])
+accuracy = tree_clf.score(data_clf[data_clf_columns],
+                          data_clf[target_clf_column])
+
 plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
-_ = plt.title(f"Shallow classification tree with max-depth of {max_depth}")
+_ = plt.title(
+    f"Shallow classification tree with max-depth of {max_depth}"
+    f"\n Accuracy of the fit: {accuracy:.2f}"
+)
 
 # %%
-plot_regression(tree_reg, data_reg[data_reg_columns],
-                data_reg[target_reg_column])
-_ = plt.title(f"Shallow regression tree with max-depth of {max_depth}")
+plot_regression(tree_reg, data_reg[data_reg_columns], data_reg[target_reg_column])
+accuracy = tree_reg.score(data_reg[data_reg_columns], data_reg[target_reg_column])
+
+_ = plt.title(
+    f"Shallow regression tree with max-depth of {max_depth}"
+    f"\n R$^2$ of the fit: {accuracy:.2f}"
+)
 
 # %% [markdown]
 # Now, let's increase the `max_depth` parameter value to check the difference
@@ -134,13 +144,24 @@ tree_reg = DecisionTreeRegressor(max_depth=max_depth)
 # %%
 plot_classification(tree_clf, data_clf[data_clf_columns],
                     data_clf[target_clf_column])
+accuracy = tree_clf.score(data_clf[data_clf_columns],
+                          data_clf[target_clf_column])
+
 plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
-_ = plt.title(f"Deep classification tree with max-depth of {max_depth}")
+_ = plt.title(
+    f"Shallow classification tree with max-depth of {max_depth}"
+    f"\n Accuracy of the fit: {accuracy:.2f}"
+)
 
 # %%
 plot_regression(tree_reg, data_reg[data_reg_columns],
                 data_reg[target_reg_column])
-_ = plt.title(f"Deep regression tree with max-depth of {max_depth}")
+accuracy = tree_reg.score(data_reg[data_reg_columns], data_reg[target_reg_column])
+
+_ = plt.title(
+    f"Shallow regression tree with max-depth of {max_depth}"
+    f"\n R$^2$ of the fit: {accuracy:.2f}"
+)
 
 # %% [markdown]
 # For both classification and regression setting, we observe that
@@ -160,15 +181,23 @@ tree_reg = GridSearchCV(DecisionTreeRegressor(), param_grid=param_grid)
 # %%
 plot_classification(tree_clf, data_clf[data_clf_columns],
                     data_clf[target_clf_column])
+accuracy = tree_clf.score(data_clf[data_clf_columns],
+                          data_clf[target_clf_column])
+
 plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
 _ = plt.title(f"Optimal depth found via CV: "
-              f"{tree_clf.best_params_['max_depth']}")
+          f"{tree_clf.best_params_['max_depth']}"
+          f"\n Accuracy of the fit: {accuracy:.2f}")
 
 # %%
 plot_regression(tree_reg, data_reg[data_reg_columns],
                 data_reg[target_reg_column])
+accuracy = tree_reg.score(data_reg[data_reg_columns],
+                          data_reg[target_reg_column])
+
 _ = plt.title(f"Optimal depth found via CV: "
-              f"{tree_reg.best_params_['max_depth']}")
+          f"{tree_reg.best_params_['max_depth']}"
+          f"\n R$^2$ of the fit: {accuracy:.2f}")
 
 # %% [markdown]
 # With this example, we see that there is not a single value that is optimal
@@ -225,7 +254,11 @@ max_depth = 2
 tree_clf = DecisionTreeClassifier(max_depth=max_depth)
 plot_classification(tree_clf, data_clf[data_clf_columns],
                     data_clf[target_clf_column])
-_ = plt.title(f"Decision tree with max-depth of {max_depth}")
+accuracy = tree_clf.score(data_clf[data_clf_columns],
+                          data_clf[target_clf_column])
+
+_ = plt.title(f"Decision tree with max-depth of {max_depth}"
+          f"\n Accuracy of the fit: {accuracy:.2f}")
 
 # %% [markdown]
 # As expected, we see that the blue blob on the right and the red blob on the
@@ -252,7 +285,11 @@ max_depth = 6
 tree_clf = DecisionTreeClassifier(max_depth=max_depth)
 plot_classification(tree_clf, data_clf[data_clf_columns],
                     data_clf[target_clf_column])
-_ = plt.title(f"Decision tree with max-depth of {max_depth}")
+accuracy = tree_clf.score(data_clf[data_clf_columns],
+                          data_clf[target_clf_column])
+
+_ = plt.title(f"Decision tree with max-depth of {max_depth}"
+          f"\n Accuracy of the fit: {accuracy:.2f}")
 
 # %%
 _, ax = plt.subplots(figsize=(11, 7))
@@ -274,15 +311,19 @@ min_samples_leaf = 60
 tree_clf = DecisionTreeClassifier(min_samples_leaf=min_samples_leaf)
 plot_classification(tree_clf, data_clf[data_clf_columns],
                     data_clf[target_clf_column])
+accuracy = tree_clf.score(data_clf[data_clf_columns],
+                          data_clf[target_clf_column])
+
 _ = plt.title(
-    f"Decision tree with leaf having at least {min_samples_leaf} samples")
+    f"Decision tree with leaf having at least {min_samples_leaf} samples"
+    f"\n Accuracy of the fit: {accuracy:.2f}")
 
 # %%
 _, ax = plt.subplots(figsize=(10, 7))
 _ = plot_tree(tree_clf, ax=ax, feature_names=data_clf_columns)
 
 # %% [markdown]
-# This hyperparameter allows to have leaves with a minimum number of samples
-# and no further splits will be search otherwise. Therefore, these
-# hyperparameters could be an alternative to fix the `max_depth`
-# hyperparameter.
+# This hyperparameter allows to have leaves with a minimum number of samples and
+# no further splits will be search otherwise. Similarly, the rest of the above
+# mentioned hyperparameters can be tuned as an alternative to fixing the
+# `max_depth`.


### PR DESCRIPTION
This PR isolate the call to score in the hyperparameter notebook.
It is linked to the comment: https://github.com/INRIA/scikit-learn-mooc/pull/464#discussion_r768893865

In this PR, we should therefore address the concern of @ogrisel:



I don't see the point of measuring the scores only the training set. Here we speak about hyper-parameter tuning so this would be confusing to only display the training score. I think this notebook needs to be reworked to do a train test split and the plots should display both training and test errors, or neither.

Maybe the plots should be duplicated to each do 2 subplots: one with the prediction function displayed on top of a scatter plot of the samples of the training set (with the training score in the title) and another with the same prediction function displayed on top of a scatter plot of the samples of the testing set (with the testing score in the title).

And then we should comment on those scores to summarize the impact of the hyper-parameters in terms of the overfitting / underfitting trade-off.
