### PR TITLE
Improve group identification in digits example

### DIFF
--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -15,11 +15,11 @@ data, target = digits.data, digits.target
 # a logistic regression classifier with preprocessor to scale the data.
 
 # %%
-from sklearn.preprocessing import StandardScaler
+from sklearn.preprocessing import MinMaxScaler
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline
 
-model = make_pipeline(StandardScaler(), LogisticRegression())
+model = make_pipeline(MinMaxScaler(), LogisticRegression(max_iter=1_000))
 
 # %% [markdown]
 # We will use the same baseline model. We will use a `KFold` cross-validation
@@ -105,7 +105,21 @@ print(digits.DESCR)
 # should either belong to the training or the testing set. Thus, we want to
 # group samples for each writer.
 #
-# Here, we will manually define the group for the 13 writers.
+# Indeed, we can recover the groups by looking at the target variable.
+
+# %%
+target[:200]
+
+# %% [markdown]
+#
+# It might not be obvious at first, but a group in the target is always
+# starting by some series of ordered digits from 0 to 9 followed by random
+# digits at a certain point. If we look in details, we see that there is 14
+# such groups, always with around 130 samples each.
+#
+# Even if it is not exactly corresponding to the 13 writers in the
+# documentation (maybe one writer wrote two series of digits), we can still use
+# this information to illustrate the problem.
 
 # %%
 from itertools import count

--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -112,14 +112,16 @@ target[:200]
 
 # %% [markdown]
 #
-# It might not be obvious at first, but a group in the target is always
-# starting by some series of ordered digits from 0 to 9 followed by random
-# digits at a certain point. If we look in details, we see that there is 14
-# such groups, always with around 130 samples each.
+# It might not be obvious at first, but there is a structure in the target:
+# there is multiple patterns that always starts by some series of ordered
+# digits from 0 to 9 followed by random digits at a certain point. If we look
+# in details, we see that there is 14 such groups, always with around 130
+# samples each.
 #
 # Even if it is not exactly corresponding to the 13 writers in the
-# documentation (maybe one writer wrote two series of digits), we can still use
-# this information to illustrate the problem.
+# documentation (maybe one writer wrote two series of digits), we can
+# make the hypothesis that each of these structure corresponds to a different
+# writer and thus a different group.
 
 # %%
 from itertools import count

--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -115,7 +115,7 @@ target[:200]
 # It might not be obvious at first, but there is a structure in the target:
 # there is multiple patterns that always starts by some series of ordered
 # digits from 0 to 9 followed by random digits at a certain point. If we look
-# in details, we see that there is 14 such groups, always with around 130
+# in details, we see that there is 14 such pattern, always with around 130
 # samples each.
 #
 # Even if it is not exactly corresponding to the 13 writers in the

--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -115,7 +115,7 @@ target[:200]
 # It might not be obvious at first, but there is a structure in the target:
 # there is multiple patterns that always starts by some series of ordered
 # digits from 0 to 9 followed by random digits at a certain point. If we look
-# in details, we see that there is 14 such pattern, always with around 130
+# in details, we see that there is 14 such patterns, always with around 130
 # samples each.
 #
 # Even if it is not exactly corresponding to the 13 writers in the

--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -113,7 +113,7 @@ target[:200]
 # %% [markdown]
 #
 # It might not be obvious at first, but there is a structure in the target:
-# there is multiple patterns that always starts by some series of ordered
+# there is a repetitive pattern that always starts by some series of ordered
 # digits from 0 to 9 followed by random digits at a certain point. If we look
 # in details, we see that there is 14 such patterns, always with around 130
 # samples each.


### PR DESCRIPTION
We have a small discrepancy between the number of writers identified in the target and the one provided by the documentation. However, we are able to show the effect of the groups. So we provide a small discussion just to avoid surprises.