### PR TITLE
Use scale instead of dispersion

### DIFF
--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -179,15 +179,15 @@ _ = plt.title("Ridge weights")
 # model through the `alpha` parameter. Therefore, the effect that feature
 # rescaling has on the final weights also interacts with regularization.
 #
-# Let's consider the case where features have an identical data dispersion: if
+# Let's consider the case where features live on the same scale/units: if
 # two features are found to be equally important by the model, they will be
 # affected similarly by regularization strength.
 #
 # Now, let's consider the scenario where features have completely different
-# data dispersion (for instance age in years and annual revenue in dollars).
+# data scale (for instance age in years and annual revenue in dollars).
 # If two features are as important, our model will boost the weights of
-# features with small dispersion and reduce the weights of features with
-# high dispersion.
+# features with small scale and reduce the weights of features with
+# high scale.
 #
 # We recall that regularization forces weights to be closer. Therefore, we get
 # an intuition that if we want to use regularization, dealing with rescaled


### PR DESCRIPTION
Partially address #276 by removing "dispersion" and using "scale" for this specific case.
