### PR TITLE
Removed imbalanced-learn from requirements

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - scikit-learn >= 0.24
-  - imbalanced-learn
   - pandas >= 1
   - matplotlib-base
   - seaborn

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,3 @@ dependencies:
   - notebook
   - jupytext
   - plotly
-  - imbalanced-learn

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 scikit-learn>=0.24
-imbalanced-learn
 pandas>=1
 matplotlib
 seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ plotly
 jupyterlab
 notebook
 jupytext
-imbalanced-learn


### PR DESCRIPTION
I think we don't use imbalanced-learn anymore since we removed this quizz question: https://gitlab.inria.fr/learninglab/mooc-scikit-learn/mooc-scikit-learn-coordination/-/commit/0c6cc16023a03309fa2eb3df95fb054c86c19647