### PR TITLE
Sprinkle M1 with comments on what the evaluation means

### DIFF
--- a/python_scripts/02_numerical_pipeline_hands_on.py
+++ b/python_scripts/02_numerical_pipeline_hands_on.py
@@ -218,8 +218,11 @@ accuracy = model.score(data_test, target_test)
 print(f"Accuracy of logistic regression: {accuracy:.3f}")
 
 # %% [markdown]
-# Now the real question is: is this generalization performance relevant of a good
-# predictive model? Find out by solving the next exercise!
+# When calling the `score` method on a classification problem, the output by
+# default is the fraction of correctly classified samples. In this case, around
+# 8 / 10 of the times, the logistic regression predicts the right income of a
+# person. Now the real question is: is this generalization performance relevant
+# of a good predictive model? Find out by solving the next exercise!
 #
 # In this notebook, we learned to:
 #

--- a/python_scripts/02_numerical_pipeline_hands_on.py
+++ b/python_scripts/02_numerical_pipeline_hands_on.py
@@ -218,8 +218,8 @@ accuracy = model.score(data_test, target_test)
 print(f"Accuracy of logistic regression: {accuracy:.3f}")
 
 # %% [markdown]
-# When calling the `score` method on a classification problem, the output by
-# default is the fraction of correctly classified samples. In this case, around
+# In scikit-learn, the `score` method of a classification model returns the accuracy,
+# i.e. the fraction of correctly classified samples. In this case, around
 # 8 / 10 of the times, the logistic regression predicts the right income of a
 # person. Now the real question is: is this generalization performance relevant
 # of a good predictive model? Find out by solving the next exercise!

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -173,8 +173,8 @@ print(f"Number of correct prediction: "
 
 # %% [markdown]
 # This result means that the model makes a correct _prediction_ for
-# approximately 82 samples out of 100. But, can a model _predict_ something
-# that it already saw? In other words, can this evaluation be trusted, or is it
+# approximately 82 samples out of 100. But, can this really be called a _prediction_ if we are predicting 
+# already learned data? In other words, can this evaluation be trusted, or is it
 # too good to be true?
 #
 # ## Train-test data split

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -173,7 +173,7 @@ print(f"Number of correct prediction: "
 
 # %% [markdown]
 # This result means that the model makes a correct _prediction_ for
-# approximately every 82 / 100 samples. But, can a model _predict_ something
+# approximately 82 samples out of 100. But, can a model _predict_ something
 # that it already saw? In other words, can this evaluation be trusted, or is it
 # too good to be true?
 #

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -92,7 +92,7 @@ print(f"The dataset contains {data.shape[0]} samples and "
 # The `fit` method is called to train the model from the input (features) and
 # target data.
 
-# %%
+# %%/
 # to display nice model diagram
 from sklearn import set_config
 set_config(display='diagram')
@@ -172,10 +172,10 @@ print(f"Number of correct prediction: "
 (target == target_predicted).mean()
 
 # %% [markdown]
-# This result means that the model makes a correct _prediction_ for
-# approximately 82 samples out of 100. But, can this really be called a _prediction_ if we are predicting 
-# already learned data? In other words, can this evaluation be trusted, or is it
-# too good to be true?
+# This result means that the model makes a correct prediction for
+# approximately 82 samples out of 100. Note that we used the same data
+# to train and evaluate our model. Can this evaluation be trusted or is
+# it to good to be true?
 #
 # ## Train-test data split
 #

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -172,7 +172,10 @@ print(f"Number of correct prediction: "
 (target == target_predicted).mean()
 
 # %% [markdown]
-# But, can this evaluation be trusted, or is it too good to be true?
+# This result means that the model makes a correct _prediction_ for
+# approximately every 82 / 100 samples. But, can a model _predict_ something
+# that it already saw? In other words, can this evaluation be trusted, or is it
+# too good to be true?
 #
 # ## Train-test data split
 #

--- a/python_scripts/video_pipeline.py
+++ b/python_scripts/video_pipeline.py
@@ -30,7 +30,8 @@ target = (target > 200_000).astype(int)
 data
 
 # %% [markdown]
-# We can cherry-pick some features and only retain this subset of data
+# For the sake of simplicity, we can cherry-pick some features and only retain
+# this subset of data
 
 # %%
 numeric_features = ['LotArea', 'FullBath', 'HalfBath']
@@ -96,3 +97,13 @@ cv_results = cross_validate(model, data, target, cv=5)
 scores = cv_results["test_score"]
 print("The mean cross-validation accuracy is: "
       f"{scores.mean():.3f} +/- {scores.std():.3f}")
+
+# %% [markdown]
+# ```{note}
+# In this case, around 86% of the times the pipeline correctly predicts whether
+# if the price of a house is above or below the 200_000 dollars threshold. But
+# be aware that this score was obtained by picking some features by hand, which
+# is in general a bad practice. As we will see later in the course, a good score
+# does not mean that the model is immune to other drawbacks such as the bias we
+# are probably introducing by ignoring the rest of the features.
+# ```

--- a/python_scripts/video_pipeline.py
+++ b/python_scripts/video_pipeline.py
@@ -31,7 +31,7 @@ data
 
 # %% [markdown]
 # For the sake of simplicity, we can cherry-pick some features and only retain
-# this subset of data
+# this arbitrary subset of data:
 
 # %%
 numeric_features = ['LotArea', 'FullBath', 'HalfBath']

--- a/python_scripts/video_pipeline.py
+++ b/python_scripts/video_pipeline.py
@@ -101,9 +101,15 @@ print("The mean cross-validation accuracy is: "
 # %% [markdown]
 # ```{note}
 # In this case, around 86% of the times the pipeline correctly predicts whether
-# if the price of a house is above or below the 200_000 dollars threshold. But
+# the price of a house is above or below the 200_000 dollars threshold. But
 # be aware that this score was obtained by picking some features by hand, which
-# is in general a bad practice. As we will see later in the course, a good score
-# does not mean that the model is immune to other drawbacks such as the bias we
-# are probably introducing by ignoring the rest of the features.
+# is not necessarily the best thing we can do for this classification task. In this
+# example we can hope that fitting a complex machine learning pipelines on a
+# richer set of features can improve upon this performance level.
+#
+# Reducing a price estimation problem to a binary classification problem with a
+# single threshold at 200_000 dollars is probably too coarse to be useful in
+# in practice. Treating this problem as a regression problem is probably a better
+# idea. We will see later in this MOOC how to train and evaluate the performance
+# of various regression models.
 # ```


### PR DESCRIPTION
Partially addresses #530.

This PR adds comments on the `score` method in the M1: 
- the first time the method is used
- the first time we use a test set for scoring
- in the pipeline video, where care has to be taken on interpreting the result naively