### PR TITLE
Fix for pandas 1.4

### DIFF
--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -67,7 +67,7 @@ y_pred = tree.predict(data_test)
 # %%
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, y_pred, label="Fitted tree")
+plt.plot(data_test["Feature"], y_pred, label="Fitted tree")
 plt.legend()
 _ = plt.title("Predictions by a single decision tree")
 
@@ -177,7 +177,7 @@ sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 for tree_idx, tree in enumerate(bag_of_trees):
     tree_predictions = tree.predict(data_test)
-    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
+    plt.plot(data_test["Feature"], tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
 
 plt.legend()
@@ -203,12 +203,12 @@ sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
 bag_predictions = []
 for tree_idx, tree in enumerate(bag_of_trees):
     tree_predictions = tree.predict(data_test)
-    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.8,
+    plt.plot(data_test["Feature"], tree_predictions, linestyle="--", alpha=0.8,
              label=f"Tree #{tree_idx} predictions")
     bag_predictions.append(tree_predictions)
 
 bag_predictions = np.mean(bag_predictions, axis=0)
-plt.plot(data_test, bag_predictions, label="Averaged predictions",
+plt.plot(data_test["Feature"], bag_predictions, label="Averaged predictions",
          linestyle="-")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 _ = plt.title("Predictions of bagged trees")
@@ -248,7 +248,7 @@ sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
 bagged_trees_predictions = bagged_trees.predict(data_test)
-plt.plot(data_test, bagged_trees_predictions)
+plt.plot(data_test["Feature"], bagged_trees_predictions)
 
 _ = plt.title("Predictions from a bagging classifier")
 
@@ -267,14 +267,14 @@ for tree_idx, tree in enumerate(bagged_trees.estimators_):
     label = "Predictions of individual trees" if tree_idx == 0 else None
     # we convert `data_test` into a NumPy array to avoid a warning raised in scikit-learn
     tree_predictions = tree.predict(data_test.to_numpy())
-    plt.plot(data_test, tree_predictions, linestyle="--", alpha=0.1,
+    plt.plot(data_test["Feature"], tree_predictions, linestyle="--", alpha=0.1,
              color="tab:blue", label=label)
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 
 bagged_trees_predictions = bagged_trees.predict(data_test)
-plt.plot(data_test, bagged_trees_predictions,
+plt.plot(data_test["Feature"], bagged_trees_predictions,
          color="tab:orange", label="Predictions of ensemble")
 _ = plt.legend()
 
@@ -339,7 +339,7 @@ for i, regressor in enumerate(bagging.estimators_):
     # we convert `data_test` into a NumPy array to avoid a warning raised in scikit-learn
     regressor_predictions = regressor.predict(data_test.to_numpy())
     base_model_line = plt.plot(
-        data_test, regressor_predictions, linestyle="--", alpha=0.2,
+        data_test["Feature"], regressor_predictions, linestyle="--", alpha=0.2,
         label="Predictions of base models" if i == 0 else None,
         color="tab:blue"
     )
@@ -347,7 +347,7 @@ for i, regressor in enumerate(bagging.estimators_):
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 bagging_predictions = bagging.predict(data_test)
-plt.plot(data_test, bagging_predictions,
+plt.plot(data_test["Feature"], bagging_predictions,
          color="tab:orange", label="Predictions of ensemble")
 plt.ylim(target_train.min(), target_train.max())
 plt.legend()

--- a/python_scripts/ensemble_gradient_boosting.py
+++ b/python_scripts/ensemble_gradient_boosting.py
@@ -75,7 +75,7 @@ target_test_predicted = tree.predict(data_test)
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
 # plot the predictions
-line_predictions = plt.plot(data_test, target_test_predicted, "--")
+line_predictions = plt.plot(data_test["Feature"], target_test_predicted, "--")
 
 # plot the residuals
 for value, true, predicted in zip(data_train["Feature"],
@@ -116,7 +116,8 @@ target_test_predicted_residuals = tree_residuals.predict(data_test)
 
 # %%
 sns.scatterplot(x=data_train["Feature"], y=residuals, color="black", alpha=0.5)
-line_predictions = plt.plot(data_test, target_test_predicted_residuals, "--")
+line_predictions = plt.plot(
+    data_test["Feature"], target_test_predicted_residuals, "--")
 
 # plot the residuals of the predicted residuals
 for value, true, predicted in zip(data_train["Feature"],
@@ -155,7 +156,7 @@ target_true_residual = residuals.iloc[-2]
 
 sns.scatterplot(x=data_train["Feature"], y=target_train, color="black",
                 alpha=0.5)
-plt.plot(data_test, target_test_predicted, "--")
+plt.plot(data_test["Feature"], target_test_predicted, "--")
 for value, true, predicted in zip(data_train["Feature"],
                                   target_train,
                                   target_train_predicted):
@@ -180,7 +181,7 @@ _ = plt.title("Tree predictions")
 
 sns.scatterplot(x=data_train["Feature"], y=residuals,
                 color="black", alpha=0.5)
-plt.plot(data_test, target_test_predicted_residuals, "--")
+plt.plot(data_test["Feature"], target_test_predicted_residuals, "--")
 for value, true, predicted in zip(data_train["Feature"],
                                   residuals,
                                   target_train_predicted_residuals):

--- a/python_scripts/ensemble_sol_02.py
+++ b/python_scripts/ensemble_sol_02.py
@@ -63,7 +63,7 @@ print(f"Mean absolute error: "
 import numpy as np
 
 data_range = pd.DataFrame(np.linspace(170, 235, num=300),
-                           columns=data.columns)
+                          columns=data.columns)
 tree_predictions = []
 for tree in forest.estimators_:
     # we convert `data_range` into a NumPy array to avoid a warning raised in scikit-learn
@@ -83,8 +83,8 @@ sns.scatterplot(data=penguins, x=feature_name, y=target_name,
 
 # plot tree predictions
 for tree_idx, predictions in enumerate(tree_predictions):
-    plt.plot(data_range, predictions, label=f"Tree #{tree_idx}",
+    plt.plot(data_range[feature_name], predictions, label=f"Tree #{tree_idx}",
              linestyle="--", alpha=0.8)
 
-plt.plot(data_range, forest_predictions, label=f"Random forest")
+plt.plot(data_range[feature_name], forest_predictions, label=f"Random forest")
 _ = plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")

--- a/python_scripts/trees_hyperparameters.py
+++ b/python_scripts/trees_hyperparameters.py
@@ -63,7 +63,7 @@ def fit_and_plot_regression(model, data, feature_names, target_names):
 
     sns.scatterplot(
         x=data.iloc[:, 0], y=data[target_names], color="black", alpha=0.5)
-    plt.plot(data_test, target_predicted, linewidth=4)
+    plt.plot(data_test.iloc[:, 0], target_predicted, linewidth=4)
 
 
 # %% [markdown]

--- a/python_scripts/trees_regression.py
+++ b/python_scripts/trees_regression.py
@@ -71,7 +71,7 @@ target_predicted = linear_model.predict(data_test)
 # %%
 sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Linear regression")
+plt.plot(data_test[feature_name], target_predicted, label="Linear regression")
 plt.legend()
 _ = plt.title("Prediction function using a LinearRegression")
 
@@ -84,7 +84,7 @@ _ = plt.title("Prediction function using a LinearRegression")
 # %%
 ax = sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                      color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Linear regression",
+plt.plot(data_test[feature_name], target_predicted, label="Linear regression",
          linestyle="--")
 plt.scatter(data_test[::3], target_predicted[::3], label="Predictions",
             color="tab:orange")
@@ -107,7 +107,7 @@ target_predicted = tree.predict(data_test)
 # %%
 sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Decision tree")
+plt.plot(data_test[feature_name], target_predicted, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction function using a DecisionTreeRegressor")
 
@@ -144,7 +144,7 @@ target_predicted = tree.predict(data_test)
 # %%
 sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted, label="Decision tree")
+plt.plot(data_test[feature_name], target_predicted, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction function using a DecisionTreeRegressor")
 

--- a/python_scripts/trees_sol_02.py
+++ b/python_scripts/trees_sol_02.py
@@ -68,9 +68,9 @@ import seaborn as sns
 
 sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted_linear_regression,
+plt.plot(data_test[feature_name], target_predicted_linear_regression,
          label="Linear regression")
-plt.plot(data_test, target_predicted_tree, label="Decision tree")
+plt.plot(data_test[feature_name], target_predicted_tree, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction of linear model and a decision tree")
 
@@ -104,9 +104,9 @@ target_predicted_tree = tree.predict(data_test)
 # %% tags=["solution"]
 sns.scatterplot(data=penguins, x=feature_name, y=target_name,
                 color="black", alpha=0.5)
-plt.plot(data_test, target_predicted_linear_regression,
+plt.plot(data_test[feature_name], target_predicted_linear_regression,
          label="Linear regression")
-plt.plot(data_test, target_predicted_tree, label="Decision tree")
+plt.plot(data_test[feature_name], target_predicted_tree, label="Decision tree")
 plt.legend()
 _ = plt.title("Prediction of linear model and a decision tree")
 


### PR DESCRIPTION
We were using:

```py
plt.plot(dataframe_single_column, array_1d)
```

This is probably edge-casy and breaks with pandas 1.4 (released a few days ago). Whether this is a regression at the interface between pandas and matploblib is debatable. We need to fix it anyway in this repo even if it eventually gets fixed in matplotlib or pandas.

I suspect this happened by coincidence, before we were using numpy arrays, and we introduced dataframes to make scikit-learn happy about having feature names at predict time. The code was working fine until it didn't ...
