### PR TITLE
Update title in YouTube videos

### DIFF
--- a/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
+++ b/jupyter-book/predictive_modeling_pipeline/03_categorical_pipeline_video.md
@@ -1,5 +1,5 @@
 # 🎥 Visualizing scikit-learn pipelines in Jupyter
 
 <iframe class="video" width="640px" height="480px"
-        src="https://www.youtube.com/embed/5ri7BhFrNe4?rel=0"
+        src="https://www.youtube.com/embed/D0Nyumrs0G4?rel=0"
         allowfullscreen></iframe>

--- a/jupyter-book/tuning/parameter_tuning_parallel_plot_video.md
+++ b/jupyter-book/tuning/parameter_tuning_parallel_plot_video.md
@@ -1,5 +1,5 @@
-# 🎥 Interactive exploration of hyper-parameter search results
+# 🎥 Analysis of hyperparameter search results
 
 <iframe class="video" width="640px" height="480px"
-        src="https://www.youtube.com/embed/mhNxkXPer2o?rel=0"
+        src="https://www.youtube.com/embed/55BweAh6X5o?rel=0"
         allowfullscreen></iframe>


### PR DESCRIPTION
The titles of the credits for the pipeline and parallel plot videos were corrected for consistency with the course titles.

These 2 videos have different links on YouTube (you can't correct/replace a video on YouTube, you have to delete the old one and reload the new one). Therefore, this PR updates the url and ensures consistency with #532 .