### PR TITLE
Explain density argument in plt.hist

### DIFF
--- a/python_scripts/cross_validation_baseline.py
+++ b/python_scripts/cross_validation_baseline.py
@@ -85,7 +85,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 bins = np.linspace(start=0, stop=100, num=80)
-all_errors.plot.hist(bins=bins, density=True, edgecolor="black")
+all_errors.plot.hist(bins=bins, edgecolor="black")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 plt.xlabel("Mean absolute error (k$)")
 _ = plt.title("Cross-validation testing errors")

--- a/python_scripts/cross_validation_ex_02.py
+++ b/python_scripts/cross_validation_ex_02.py
@@ -81,6 +81,3 @@ data, target = adult_census.drop(columns="class"), adult_census["class"]
 
 # %%
 # Write your code here.
-
-# %%
-# Write your code here.

--- a/python_scripts/cross_validation_grouping.py
+++ b/python_scripts/cross_validation_grouping.py
@@ -66,7 +66,7 @@ all_scores = pd.DataFrame(
 # %%
 import matplotlib.pyplot as plt
 
-all_scores.plot.hist(bins=10, edgecolor="black", density=True, alpha=0.7)
+all_scores.plot.hist(bins=10, edgecolor="black", alpha=0.7)
 plt.xlim([0.8, 1.0])
 plt.xlabel("Accuracy score")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
@@ -177,7 +177,7 @@ all_scores = pd.DataFrame(
 ).T
 
 # %%
-all_scores.plot.hist(bins=10, edgecolor="black", density=True, alpha=0.7)
+all_scores.plot.hist(bins=10, edgecolor="black", alpha=0.7)
 plt.xlim([0.8, 1.0])
 plt.xlabel("Accuracy score")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")

--- a/python_scripts/cross_validation_sol_02.py
+++ b/python_scripts/cross_validation_sol_02.py
@@ -101,7 +101,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 bins = np.linspace(start=0.5, stop=1.0, num=100)
-all_test_scores.plot.hist(bins=bins, density=True, edgecolor="black")
+all_test_scores.plot.hist(bins=bins, edgecolor="black")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 plt.xlabel("Accuracy (%)")
 _ = plt.title("Distribution of the CV scores")

--- a/python_scripts/cross_validation_sol_02.py
+++ b/python_scripts/cross_validation_sol_02.py
@@ -157,7 +157,7 @@ all_test_scores = pd.concat(
 )
 
 # %% tags=["solution"]
-all_test_scores.plot.hist(bins=bins, density=True, edgecolor="black")
+all_test_scores.plot.hist(bins=bins, edgecolor="black")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 plt.xlabel("Accuracy (%)")
 _ = plt.title("Distribution of the test scores")

--- a/python_scripts/cross_validation_sol_02.py
+++ b/python_scripts/cross_validation_sol_02.py
@@ -136,8 +136,7 @@ test_score_dummy_stratified = pd.Series(
     cv_results_stratified["test_score"], name="Stratified class predictor"
 )
 
-# %%
-# solution
+# %% tags=["solution"]
 uniform_dummy = DummyClassifier(strategy="uniform")
 cv_results_uniform = cross_validate(
     uniform_dummy, data, target, cv=cv, n_jobs=2

--- a/python_scripts/cross_validation_train_test.py
+++ b/python_scripts/cross_validation_train_test.py
@@ -253,15 +253,11 @@ len(cv_results)
 # %%
 import matplotlib.pyplot as plt
 
-cv_results["test_error"].plot.hist(bins=10, edgecolor="black", density=True)
+cv_results["test_error"].plot.hist(bins=10, edgecolor="black")
 plt.xlabel("Mean absolute error (k$)")
 _ = plt.title("Test error distribution")
 
 # %% [markdown]
-# The argument `density=True` in the plot above normalizes the histogram such
-# that the sum of the histogram areas is one, i.e. the probability to be in a
-# bin can be obtained by multiplying the height by the width of the bin.
-#
 # We observe that the testing error is clustered around 47 k\$ and ranges from
 # 43 k\$ to 50 k\$.
 
@@ -288,7 +284,7 @@ print(f"The standard deviation of the testing error is: "
 # Let us plot the distribution of the target variable:
 
 # %%
-target.plot.hist(bins=20, edgecolor="black", density=True)
+target.plot.hist(bins=20, edgecolor="black")
 plt.xlabel("Median House Value (k$)")
 _ = plt.title("Target distribution")
 

--- a/python_scripts/cross_validation_train_test.py
+++ b/python_scripts/cross_validation_train_test.py
@@ -258,6 +258,10 @@ plt.xlabel("Mean absolute error (k$)")
 _ = plt.title("Test error distribution")
 
 # %% [markdown]
+# The argument `density=True` in the plot above normalizes the histogram such
+# that the sum of the histogram areas is one, i.e. the probability to be in a
+# bin can be obtained by multiplying the height by the width of the bin.
+#
 # We observe that the testing error is clustered around 47 k\$ and ranges from
 # 43 k\$ to 50 k\$.
 

--- a/python_scripts/cross_validation_validation_curve.py
+++ b/python_scripts/cross_validation_validation_curve.py
@@ -59,7 +59,7 @@ scores[["train error", "test error"]] = -cv_results[
 # %%
 import matplotlib.pyplot as plt
 
-scores.plot.hist(bins=50, edgecolor="black", density=True)
+scores.plot.hist(bins=50, edgecolor="black")
 plt.xlabel("Mean absolute error (k$)")
 _ = plt.title("Train and test errors distribution via cross-validation")
 

--- a/python_scripts/datasets_ames_housing.py
+++ b/python_scripts/datasets_ames_housing.py
@@ -80,7 +80,7 @@ numerical_data.info()
 # a look at the histogram for all these features.
 
 # %%
-numerical_data.hist(bins=20, figsize=(12, 22), edgecolor="black", density=True,
+numerical_data.hist(bins=20, figsize=(12, 22), edgecolor="black",
                     layout=(9, 4))
 plt.subplots_adjust(hspace=0.8, wspace=0.8)
 

--- a/python_scripts/datasets_bike_rides.py
+++ b/python_scripts/datasets_bike_rides.py
@@ -88,7 +88,7 @@ data, target = cycling.drop(columns=target_name), cycling[target_name]
 # %%
 import matplotlib.pyplot as plt
 
-target.plot.hist(bins=50, edgecolor="black", density=True)
+target.plot.hist(bins=50, edgecolor="black")
 plt.xlabel("Power (W)")
 
 # %% [markdown]

--- a/python_scripts/datasets_blood_transfusion.py
+++ b/python_scripts/datasets_blood_transfusion.py
@@ -56,7 +56,7 @@ data.info()
 # distributions.
 
 # %%
-_ = data.hist(figsize=(12, 10), bins=30, edgecolor="black", density=True)
+_ = data.hist(figsize=(12, 10), bins=30, edgecolor="black")
 
 # %% [markdown]
 # There is nothing shocking regarding the distributions. We only observe a high

--- a/python_scripts/logistic_regression.py
+++ b/python_scripts/logistic_regression.py
@@ -34,8 +34,7 @@ import matplotlib.pyplot as plt
 for feature_name in culmen_columns:
     plt.figure()
     # plot the histogram for each specie
-    penguins.groupby("Species")[feature_name].plot.hist(
-        alpha=0.5, density=True, legend=True)
+    penguins.groupby("Species")[feature_name].plot.hist(alpha=0.5, legend=True)
     plt.xlabel(feature_name)
 
 # %% [markdown]


### PR DESCRIPTION
Partially addresses #539.

This PR removes the `density=True` argument when comparing baselines in M7 as suggested in [this forum comment](https://mooc-forums.inria.fr/moocsl/t/density-argument-in-plt-hist/4191/2).

It also introduces a brief explanation the first time this argument appears.

Side effect: removes an unnecessary (blank) solution cell.