### PR TITLE
Improve description on how to access help inside notebook

### DIFF
--- a/python_scripts/02_numerical_pipeline_ex_00.py
+++ b/python_scripts/02_numerical_pipeline_ex_00.py
@@ -39,8 +39,13 @@ target = adult_census["class"]
 # data point.
 #
 # What is the default value of the `n_neighbors` parameter? Hint: Look at the
-# help inside your notebook `KNeighborsClassifier?` or on the [scikit-learn
+# documentation on the [scikit-learn
 # website](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html)
+# or directly access the description inside your notebook by running
+# `KNeighborsClassifier?` after the respective import.
+
+# %%
+# Write your code here.
 
 # %% [markdown]
 # Create a `KNeighborsClassifier` model with `n_neighbors=50`

--- a/python_scripts/02_numerical_pipeline_ex_00.py
+++ b/python_scripts/02_numerical_pipeline_ex_00.py
@@ -41,11 +41,17 @@ target = adult_census["class"]
 # What is the default value of the `n_neighbors` parameter? Hint: Look at the
 # documentation on the [scikit-learn
 # website](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html)
-# or directly access the description inside your notebook by running
-# `KNeighborsClassifier?` after the respective import.
+# or directly access the description inside your notebook by running the
+# following cell:
 
 # %%
-# Write your code here.
+from sklearn.neighbors import KNeighborsClassifier
+
+# KNeighborsClassifier?
+
+# %% [markdown]
+# This will open a pager pointing to the documentation, where we can see that
+# the default value for `n_neighbors` is 5.
 
 # %% [markdown]
 # Create a `KNeighborsClassifier` model with `n_neighbors=50`

--- a/python_scripts/02_numerical_pipeline_ex_00.py
+++ b/python_scripts/02_numerical_pipeline_ex_00.py
@@ -42,16 +42,12 @@ target = adult_census["class"]
 # documentation on the [scikit-learn
 # website](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html)
 # or directly access the description inside your notebook by running the
-# following cell:
+# following cell. This will open a pager pointing to the documentation.
 
 # %%
 from sklearn.neighbors import KNeighborsClassifier
 
 # KNeighborsClassifier?
-
-# %% [markdown]
-# This will open a pager pointing to the documentation, where we can see that
-# the default value for `n_neighbors` is 5.
 
 # %% [markdown]
 # Create a `KNeighborsClassifier` model with `n_neighbors=50`

--- a/python_scripts/02_numerical_pipeline_sol_00.py
+++ b/python_scripts/02_numerical_pipeline_sol_00.py
@@ -38,8 +38,16 @@ target = adult_census["class"]
 # data point.
 #
 # What is the default value of the `n_neighbors` parameter? Hint: Look at the
-# help inside your notebook `KNeighborsClassifier?` or on the [scikit-learn
+# documentation on the [scikit-learn
 # website](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html)
+# or directly access the description inside your notebook by running
+# `KNeighborsClassifier?` after the respective import.
+
+# %%
+# solution
+from sklearn.neighbors import KNeighborsClassifier
+
+KNeighborsClassifier?
 
 # %% [markdown] tags=["solution"]
 # The default value for `n_neighbors` is 5
@@ -49,8 +57,6 @@ target = adult_census["class"]
 
 # %%
 # solution
-from sklearn.neighbors import KNeighborsClassifier
-
 model = KNeighborsClassifier(n_neighbors=50)
 
 # %% [markdown]

--- a/python_scripts/02_numerical_pipeline_sol_00.py
+++ b/python_scripts/02_numerical_pipeline_sol_00.py
@@ -41,16 +41,15 @@ target = adult_census["class"]
 # documentation on the [scikit-learn
 # website](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html)
 # or directly access the description inside your notebook by running the
-# following cell:
+# following cell. This will open a pager pointing to the documentation.
 
 # %%
 from sklearn.neighbors import KNeighborsClassifier
 
 KNeighborsClassifier?
 
-# %% [markdown]
-# This will open a pager pointing to the documentation, where we can see that
-# the default value for `n_neighbors` is 5.
+# %% [markdown] tags=["solution"]
+# We can see that the default value for `n_neighbors` is 5.
 
 # %% [markdown]
 # Create a `KNeighborsClassifier` model with `n_neighbors=50`

--- a/python_scripts/02_numerical_pipeline_sol_00.py
+++ b/python_scripts/02_numerical_pipeline_sol_00.py
@@ -40,17 +40,17 @@ target = adult_census["class"]
 # What is the default value of the `n_neighbors` parameter? Hint: Look at the
 # documentation on the [scikit-learn
 # website](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html)
-# or directly access the description inside your notebook by running
-# `KNeighborsClassifier?` after the respective import.
+# or directly access the description inside your notebook by running the
+# following cell:
 
 # %%
-# solution
 from sklearn.neighbors import KNeighborsClassifier
 
 KNeighborsClassifier?
 
-# %% [markdown] tags=["solution"]
-# The default value for `n_neighbors` is 5
+# %% [markdown]
+# This will open a pager pointing to the documentation, where we can see that
+# the default value for `n_neighbors` is 5.
 
 # %% [markdown]
 # Create a `KNeighborsClassifier` model with `n_neighbors=50`


### PR DESCRIPTION
In the [Solution for Exercise M1.02](https://inria.github.io/scikit-learn-mooc/python_scripts/02_numerical_pipeline_sol_00.html) we present how to access the description of a model using, for instance, the syntax `KNeighborsClassifier?` in this particular case.
I think the description could be improved, as it may not be clear for beginners that the `?` character was not a typo, but part of code we expected them to try.