### PR TITLE
Fix content_only js

### DIFF
--- a/jupyter-book/_static/sklearn_mooc.js
+++ b/jupyter-book/_static/sklearn_mooc.js
@@ -1,36 +1,43 @@
-(function(){
-  function inIframe() {
-    try {
-      return window.self !== window.top;
-    } catch (e) {
-      return true;
+(function() {
+    function inIframe() {
+        try {
+            return window.self !== window.top;
+        } catch (e) {
+            return true;
+        }
     }
-  }
 
-  function contentOnly() {
-    var urlParams = new URLSearchParams(window.location.search);
-    return urlParams.get('content_only') !== null;
-  }
-
-  function displayContentOnly() {
-    document.querySelector('#site-navigation').remove();
-    document.querySelector('.topbar').remove();
-    document.querySelector('.prev-next-bottom').remove();
-    document.querySelector('.footer').remove();
-    var elementsToRemove = document.querySelectorAll('.remove-from-content-only');
-    elementsToRemove.forEach(
-      function(el) { el.remove(); }
-    );
-    document.querySelector('#main-content').querySelector('.col-md-9').className = 'col-12';
-
-    var style=document.createElement('style');
-    style.appendChild(document.createTextNode('hypothesis-sidebar, hypothesis-notebook, hypothesis-adder{display:none!important;}'));
-    document.getElementsByTagName('head')[0].appendChild(style);
-  }
-
-  document.addEventListener("DOMContentLoaded", function() {
-    if (inIframe() || contentOnly()) {
-      displayContentOnly();
+    function contentOnly() {
+        var urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get('content_only') !== null;
     }
-  });
+
+    function removeIfExists(el) {
+        if (el) {
+            el.remove();
+        };
+    }
+
+    function displayContentOnly() {
+        removeIfExists(document.querySelector('#site-navigation'));
+        removeIfExists(document.querySelector('.topbar'));
+        removeIfExists(document.querySelector('.footer'));
+        var elementsToRemove = document.querySelectorAll('.remove-from-content-only');
+        elementsToRemove.forEach(
+            function(el) {
+                removeIfExists(el);
+            }
+        );
+        document.querySelector('#main-content').querySelector('.col-md-9').className = 'col-12';
+
+        var style = document.createElement('style');
+        style.appendChild(document.createTextNode('hypothesis-sidebar, hypothesis-notebook, hypothesis-adder{display:none!important;}'));
+        document.getElementsByTagName('head')[0].appendChild(style);
+    }
+
+    document.addEventListener("DOMContentLoaded", function() {
+        if (inIframe() || contentOnly()) {
+            displayContentOnly();
+        }
+    });
 }());


### PR DESCRIPTION
Fix #559

Turns out the problem `document.querySelector('.prev-next-bottom')` was null so this line was failing 
```
document.querySelector('.prev-next-bottom').remove();
```
and the rest of the lines were not run ... including the lines that add some CSS to hide the hypothesis sidebar.

I also ran js-beautify on the file since I was fighting against my editor and writing js is already a pain enough