### PR TITLE
Add concluding remarks video

### DIFF
--- a/jupyter-book/_toc.yml
+++ b/jupyter-book/_toc.yml
@@ -227,6 +227,7 @@ parts:
   - file: interpretation/interpretation_quiz
 - caption: Concluding remarks
   chapters:
+  - file: concluding_remarks_video.md
   - file: concluding_remarks.md
 - caption: Appendix
   chapters:

--- a/jupyter-book/concluding_remarks_video.md
+++ b/jupyter-book/concluding_remarks_video.md
@@ -1,0 +1,5 @@
+# 🎥 Concluding remarks
+
+<iframe class="video" width="640px" height="480px"
+        src="https://www.youtube.com/embed/dqnPOlPYA4s?rel=0"
+        allowfullscreen></iframe>


### PR DESCRIPTION
We discussed the possibility of having the video in the same page as the [concluding remarks](https://inria.github.io/scikit-learn-mooc/concluding_remarks.html), but we also mentioned that we should keep a similar format as in FUN, where we placed the video in its own page. This PR does the latter, as this may also help avoiding a very charged and long page.