### PR TITLE
Regenerate exercises with make exercises

### DIFF
--- a/python_scripts/01_tabular_data_exploration_ex_01.py
+++ b/python_scripts/01_tabular_data_exploration_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/02_numerical_pipeline_ex_00.py
+++ b/python_scripts/02_numerical_pipeline_ex_00.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/02_numerical_pipeline_ex_01.py
+++ b/python_scripts/02_numerical_pipeline_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/cross_validation_ex_01.py
+++ b/python_scripts/cross_validation_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/cross_validation_ex_02.py
+++ b/python_scripts/cross_validation_ex_02.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/ensemble_ex_01.py
+++ b/python_scripts/ensemble_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/ensemble_ex_02.py
+++ b/python_scripts/ensemble_ex_02.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/ensemble_ex_03.py
+++ b/python_scripts/ensemble_ex_03.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/ensemble_ex_04.py
+++ b/python_scripts/ensemble_ex_04.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/feature_selection_ex_01.py
+++ b/python_scripts/feature_selection_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_01.py
+++ b/python_scripts/linear_models_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_02.py
+++ b/python_scripts/linear_models_ex_02.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_03.py
+++ b/python_scripts/linear_models_ex_03.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_04.py
+++ b/python_scripts/linear_models_ex_04.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_05.py
+++ b/python_scripts/linear_models_ex_05.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/metrics_ex_01.py
+++ b/python_scripts/metrics_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/metrics_ex_02.py
+++ b/python_scripts/metrics_ex_02.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/parameter_tuning_ex_02.py
+++ b/python_scripts/parameter_tuning_ex_02.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/parameter_tuning_ex_03.py
+++ b/python_scripts/parameter_tuning_ex_03.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/trees_ex_01.py
+++ b/python_scripts/trees_ex_01.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/trees_ex_02.py
+++ b/python_scripts/trees_ex_02.py
@@ -1,5 +1,12 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.5
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3


### PR DESCRIPTION
Follow-up of #579.

This puts back exercises as generated by `make exercises`.

I looked a bit in the jupytext code, but there is no straightforward way to remove the jupytext header, see https://github.com/INRIA/scikit-learn-mooc/pull/408#issuecomment-1041463684.

I assume it's the same thing for the `utf-8 first line`. Note that the reason that `utf-8` appeared in the rendering was that they were after the yaml frontmatter due to #576 adding frontmatter at the top where there was none. Having them in the first line (or at least before the front matter) will not cause them to show up in the rendered HTML or notebook.

We could get rid of jupytext info in the frontmatter by hand if we really wanted to, there is an old TODO about this in https://github.com/INRIA/scikit-learn-mooc/blob/f5ed939ed3f259137830af1e1433bcf9f30ed5de/build_tools/generate-exercise-from-solution.py#L41-L43 but I feel this is not super high priority.