### PR TITLE
Remove interpretation of scores that depends on `random_state`

### DIFF
--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -227,19 +227,6 @@ cv_results = cv_results.rename(shorten_param, axis=1)
 cv_results
 
 # %% [markdown]
-# The best model that we found with this search seems to have a substantially better
-# mean test score than the second to best model, as the difference of the mean test
-# scores of both models differs by more than three times the standard deviation of the
-# cross-validated test scores of the best model.
-
-# %%
-cv_results = cv_results.set_index("rank_test_score")
-cv_results["mean_test_score"][1] - cv_results["mean_test_score"][2]
-
-# %%
-3 * cv_results["std_test_score"][1]
-
-# %% [markdown]
 # Keep in mind that tuning is limited by the number of different combinations
 # of parameters that are scored by the randomized search. In fact, there might
 # be other sets of parameters leading to similar or better generalization


### PR DESCRIPTION
Somewhat related to  #304. In the [randomized search notebook](https://inria.github.io/scikit-learn-mooc/python_scripts/parameter_tuning_randomized_search.html) we still use a notion of "substantially better" based on comparing the difference of the mean test scores of two models w.r.t. the standard deviation of said scores.

Furthermore, in this case the difference depends on the `random_state` as mentioned in [this forum post](https://mooc-forums.inria.fr/moocsl/t/no-significance-between-the-2-best-models/7689/2). Therefore, the conclusions drawn are not true and are in contradiction with the following paragraph: 

> In fact, there might be other sets of parameters leading to similar or better generalization performances but that were not tested in the search.

This PR simply removes this misinterpretation.