### PR TITLE
Use IPython 7 as a temporary work-around

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,6 +9,8 @@ dependencies:
   - plotly
   - jupytext
   - beautifulsoup4
+  # temporary work-around for https://github.com/ipython/ipython/issues/12467
+  - IPython<8
   - pip
   - pip:
     - jupyter-book >= 0.11

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,5 @@ dependencies:
   - notebook
   - jupytext
   - plotly
+  # temporary work-around for https://github.com/ipython/ipython/issues/12467
+  - IPython<8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ plotly
 jupyter-book>=0.11
 jupytext
 beautifulsoup4
+# temporary work-around for https://github.com/ipython/ipython/issues/12467
+IPython<8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ plotly
 jupyterlab
 notebook
 jupytext
+# temporary work-around for https://github.com/ipython/ipython/issues/12467
+IPython<8


### PR DESCRIPTION
This is to avoid https://github.com/ipython/ipython/issues/12467#issuecomment-1031486805.

This affects the MOOC since errors inside `joblib.Parallel` with `n_jobs > 1` looks like cells than runs forever without any output e.g. https://mooc-forums.inria.fr/moocsl/t/q7-taking-too-long-to-run-validation-curve-on-data/8023/8