### PR TITLE
Add matomo

### DIFF
--- a/jupyter-book/_static/matomo.js
+++ b/jupyter-book/_static/matomo.js
@@ -1,0 +1,15 @@
+var _paq = window._paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+    var u = "https://piwik.inria.fr/";
+    _paq.push(['setTrackerUrl', u + 'piwik.php']);
+    _paq.push(['setSiteId', '127']);
+    var d = document,
+        g = d.createElement('script'),
+        s = d.getElementsByTagName('script')[0];
+    g.async = true;
+    g.src = u + 'piwik.js';
+    s.parentNode.insertBefore(g, s);
+})();


### PR DESCRIPTION
I tried to test this locally but I don't seem to be able to see visits in our [Matomo page]( https://piwik.inria.fr/index.php?module=CoreHome&action=index&idSite=127&period=day&date=yesterday#?period=day&date=2022-03-08&category=Dashboard_Dashboard&subcategory=1)

I tried disabling all ad-blockers or similar extensions and "do not track" setting, to no avail.

Let's see in the CircleCI artifact if somehow this works.