### PR TITLE
Fix learning curve to show overlapped error bars

### DIFF
--- a/python_scripts/cross_validation_sol_01.py
+++ b/python_scripts/cross_validation_sol_01.py
@@ -121,9 +121,9 @@ train_scores, test_scores = validation_curve(
 import matplotlib.pyplot as plt
 
 plt.errorbar(gammas, train_scores.mean(axis=1),
-             yerr=train_scores.std(axis=1), label='Training score')
+             yerr=train_scores.std(axis=1), alpha = 0.95, label='Training score')
 plt.errorbar(gammas, test_scores.mean(axis=1),
-             yerr=test_scores.std(axis=1), label='Testing score')
+             yerr=test_scores.std(axis=1), alpha = 0.5, label='Testing score')
 plt.legend()
 
 plt.xscale("log")
@@ -156,9 +156,9 @@ train_size, train_scores, test_scores = results[:3]
 
 # %% tags=["solution"]
 plt.errorbar(train_size, train_scores.mean(axis=1),
-             yerr=train_scores.std(axis=1), label='Training score')
+             yerr=train_scores.std(axis=1), alpha = 0.95, label='Training score')
 plt.errorbar(train_size, test_scores.mean(axis=1),
-             yerr=test_scores.std(axis=1), label='Testing score')
+             yerr=test_scores.std(axis=1), alpha = 0.5, label='Testing score')
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 
 plt.xlabel("Number of samples in the training set")

--- a/python_scripts/cross_validation_sol_01.py
+++ b/python_scripts/cross_validation_sol_01.py
@@ -10,12 +10,11 @@
 #
 # The aim of this exercise is to make the following experiments:
 #
-# * train and test a support vector machine classifier through
-#   cross-validation;
+# * train and test a support vector machine classifier through cross-validation;
 # * study the effect of the parameter gamma of this classifier using a
 #   validation curve;
-# * use a learning curve to determine the usefulness of adding new
-#   samples in the dataset when building a classifier.
+# * use a learning curve to determine the usefulness of adding new samples in
+#   the dataset when building a classifier.
 #
 # To make these experiments we will first load the blood transfusion dataset.
 
@@ -34,14 +33,14 @@ target = blood_transfusion["Class"]
 
 # %% [markdown]
 # We will use a support vector machine classifier (SVM). In its most simple
-# form, a SVM classifier is a linear classifier behaving similarly to a
-# logistic regression. Indeed, the optimization used to find the optimal
-# weights of the linear model are different but we don't need to know these
-# details for the exercise.
+# form, a SVM classifier is a linear classifier behaving similarly to a logistic
+# regression. Indeed, the optimization used to find the optimal weights of the
+# linear model are different but we don't need to know these details for the
+# exercise.
 #
-# Also, this classifier can become more flexible/expressive by using a
-# so-called kernel that makes the model become non-linear. Again, no requirement
-# regarding the mathematics is required to accomplish this exercise.
+# Also, this classifier can become more flexible/expressive by using a so-called
+# kernel that makes the model become non-linear. Again, no requirement regarding
+# the mathematics is required to accomplish this exercise.
 #
 # We will use an RBF kernel where a parameter `gamma` allows to tune the
 # flexibility of the model.
@@ -63,12 +62,13 @@ from sklearn.svm import SVC
 model = make_pipeline(StandardScaler(), SVC())
 
 # %% [markdown]
-# Evaluate the generalization performance of your model by cross-validation with a
-# `ShuffleSplit` scheme. Thus, you can use
+# Evaluate the generalization performance of your model by cross-validation with
+# a `ShuffleSplit` scheme. Thus, you can use
 # [`sklearn.model_selection.cross_validate`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html)
-# and pass a [`sklearn.model_selection.ShuffleSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ShuffleSplit.html)
-# to the `cv` parameter. Only fix the `random_state=0` in the `ShuffleSplit`
-# and let the other parameters to the default.
+# and pass a
+# [`sklearn.model_selection.ShuffleSplit`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ShuffleSplit.html)
+# to the `cv` parameter. Only fix the `random_state=0` in the `ShuffleSplit` and
+# let the other parameters to the default.
 
 # %%
 # solution
@@ -91,11 +91,11 @@ print(
 # controlling under/over-fitting in support vector machine with an RBF kernel.
 #
 # Evaluate the effect of the parameter `gamma` by using the
-# [`sklearn.model_selection.validation_curve`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.validation_curve.html) function.
-# You can leave the default `scoring=None` which is equivalent to
-# `scoring="accuracy"` for classification problems. You can vary `gamma`
-# between `10e-3` and `10e2` by generating samples on a logarithmic scale
-# with the help of `np.logspace(-3, 2, num=30)`.
+# [`sklearn.model_selection.validation_curve`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.validation_curve.html)
+# function. You can leave the default `scoring=None` which is equivalent to
+# `scoring="accuracy"` for classification problems. You can vary `gamma` between
+# `10e-3` and `10e2` by generating samples on a logarithmic scale with the help
+# of `np.logspace(-3, 2, num=30)`.
 #
 # Since we are manipulating a `Pipeline` the parameter name will be set to
 # `svc__gamma` instead of only `gamma`. You can retrieve the parameter name
@@ -120,10 +120,20 @@ train_scores, test_scores = validation_curve(
 # solution
 import matplotlib.pyplot as plt
 
-plt.errorbar(gammas, train_scores.mean(axis=1),
-             yerr=train_scores.std(axis=1), alpha = 0.95, label='Training score')
-plt.errorbar(gammas, test_scores.mean(axis=1),
-             yerr=test_scores.std(axis=1), alpha = 0.5, label='Testing score')
+plt.errorbar(
+    gammas,
+    train_scores.mean(axis=1),
+    yerr=train_scores.std(axis=1),
+    alpha=0.95,
+    label="Training score",
+)
+plt.errorbar(
+    gammas,
+    test_scores.mean(axis=1),
+    yerr=test_scores.std(axis=1),
+    alpha=0.5,
+    label="Testing score",
+)
 plt.legend()
 
 plt.xscale("log")
@@ -132,11 +142,10 @@ plt.ylabel("Accuracy score")
 _ = plt.title("Validation score of support vector machine")
 
 # %% [markdown] tags=["solution"]
-# Looking at the curve, we can clearly identify the over-fitting regime of
-# the SVC classifier when `gamma > 1`.
-# The best setting is around `gamma = 1` while for `gamma < 1`,
-# it is not very clear if the classifier is under-fitting but the
-# testing score is worse than for `gamma = 1`.
+# Looking at the curve, we can clearly identify the over-fitting regime of the
+# SVC classifier when `gamma > 1`. The best setting is around `gamma = 1` while
+# for `gamma < 1`, it is not very clear if the classifier is under-fitting but
+# the testing score is worse than for `gamma = 1`.
 
 # %% [markdown]
 # Now, you can perform an analysis to check whether adding new samples to the
@@ -155,10 +164,20 @@ results = learning_curve(
 train_size, train_scores, test_scores = results[:3]
 
 # %% tags=["solution"]
-plt.errorbar(train_size, train_scores.mean(axis=1),
-             yerr=train_scores.std(axis=1), alpha = 0.95, label='Training score')
-plt.errorbar(train_size, test_scores.mean(axis=1),
-             yerr=test_scores.std(axis=1), alpha = 0.5, label='Testing score')
+plt.errorbar(
+    train_size,
+    train_scores.mean(axis=1),
+    yerr=train_scores.std(axis=1),
+    alpha=0.95,
+    label="Training score",
+)
+plt.errorbar(
+    train_size,
+    test_scores.mean(axis=1),
+    yerr=test_scores.std(axis=1),
+    alpha=0.5,
+    label="Testing score",
+)
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 
 plt.xlabel("Number of samples in the training set")
@@ -166,7 +185,6 @@ plt.ylabel("Accuracy")
 _ = plt.title("Learning curve for support vector machine")
 
 # %% [markdown] tags=["solution"]
-# We observe that adding new samples in the dataset does not improve the
-# testing score. We can only conclude that the standard deviation of
-# the training error is decreasing when adding more samples which is not a
-# surprise.
+# We observe that adding new samples in the dataset does not improve the testing
+# score. We can only conclude that the standard deviation of the training error
+# is decreasing when adding more samples which is not a surprise.


### PR DESCRIPTION
As mentioned in [this forum post](https://mooc-forums.inria.fr/moocsl/t/suggestion-in-exercice-m2-01-add-transparency-to-plt-errorbar/8969):

> people could believe than there are no standard deviations for training scores for gammas <1 because on the graph these std are hidden by the testing scores’ ones. Adding transparency to the graph with the alpha parameter fixes it.