### PR TITLE
Remove not super useful set_config diagram

### DIFF
--- a/notebooks/02_numerical_pipeline_hands_on.ipynb
+++ b/notebooks/02_numerical_pipeline_hands_on.ipynb
@@ -333,17 +333,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# to display nice model diagram\n",
-    "from sklearn import set_config\n",
-    "set_config(display='diagram')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from sklearn.linear_model import LogisticRegression\n",
     "\n",
     "model = LogisticRegression()"

--- a/python_scripts/02_numerical_pipeline_hands_on.py
+++ b/python_scripts/02_numerical_pipeline_hands_on.py
@@ -198,11 +198,6 @@ print(f"Number of samples in training: {data_train.shape[0]} => "
 # To create a logistic regression model in scikit-learn you can do:
 
 # %%
-# to display nice model diagram
-from sklearn import set_config
-set_config(display='diagram')
-
-# %%
 from sklearn.linear_model import LogisticRegression
 
 model = LogisticRegression()


### PR DESCRIPTION
https://inria.github.io/scikit-learn-mooc/python_scripts/02_numerical_pipeline_hands_on.html

The only place this is used is here:
![image](https://user-images.githubusercontent.com/1680079/159042851-4ccfdffa-0e61-4427-b23d-a21cad67b458.png)

I think it is fine to start using HTML diagrams in the next notebook where at least there is a pipeline.

If we want to keep it, we may put the `set_config` code somewhere else (e.g. at the beginning of the notebook) since with the sentence before it looks like this is part of creating the `LogisticRegression`