### PR TITLE
Fix typo s/might have reach/might have reached

### DIFF
--- a/python_scripts/cross_validation_learning_curve.py
+++ b/python_scripts/cross_validation_learning_curve.py
@@ -111,7 +111,7 @@ _ = plt.title("Learning curve for decision tree")
 # more samples into the training set.
 #
 # If we achieve a plateau and adding new samples in the training set does not
-# reduce the testing error, we might have reach the Bayes error rate using the
+# reduce the testing error, we might have reached the Bayes error rate using the
 # available model. Using a more complex model might be the only possibility to
 # reduce the testing error further.
 #


### PR DESCRIPTION
Hi,

Quick fix for a typo. Also, I had to Google [Bayes error rate](https://en.wikipedia.org/wiki/Bayes_error_rate) after reading this paragraph, but I couldn't find a link in the notebook for that. Are there any plans to have footnotes (like in GitHub Markdown [^1]) with useful links? Or maybe these links are in the forum or somewhere else?

Thanks!

[^1]: for example