### PR TITLE
Improve description in caution message

### DIFF
--- a/python_scripts/03_categorical_pipeline_column_transformer.py
+++ b/python_scripts/03_categorical_pipeline_column_transformer.py
@@ -152,8 +152,10 @@ data_train, data_test, target_train, target_test = train_test_split(
 #
 # ```{caution}
 # Be aware that we use `train_test_split` here for didactic purposes, to show
-# the scikit-learn API. In a real setting one should use cross-validation as
-# previously demonstrated.
+# the scikit-learn API. In a real setting one might prefer to use
+# cross-validation to also be able to evaluate the uncertainty of
+# our estimation of the generalization performance of a model,
+# as previously demonstrated.
 # ```
 #
 # Now, we can train the model on the train set.


### PR DESCRIPTION
[This forum post](https://mooc-forums.inria.fr/moocsl/t/caution-and-after/8686) shows that we can better explain our reasoning for using a train-test split instead of cross-validation.

This PR aims to fix that with minimal text. An alternative is to say "should prefer cross-validation" instead of "should use cross-validation".