### PR TITLE
Add hyperlink to contributing guide in the concluding remarks

### DIFF
--- a/jupyter-book/concluding_remarks.md
+++ b/jupyter-book/concluding_remarks.md
@@ -94,7 +94,7 @@ Let us give a few pointers on going further with machine learning.
     - Build a community: helping each other, helping training, communication,
       advocacy
     - Curate information: our developers have information overflow
-    - Contributing code is technical
+    - [Contributing code](https://scikit-learn.org/stable/developers/contributing.html#contributing-code) is technical
 	- Learn software engineering (if you don't know where to start,
      [Software Carpentry](https://software-carpentry.org/lessons) is a good
      resource)


### PR DESCRIPTION
We have some users that want to go beyond the "Going further" section of the concluding remarks (see for instance [this forum post](https://mooc-forums.inria.fr/moocsl/t/many-thanks-to-inria-for-this-great-mooc/10949)).

This PR aims to help them find how to contribute to scikit-learn more easily.