### PR TITLE
MNT bump Python version to be compatible with scikit-learn 1.1

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -15,11 +15,11 @@ jobs:
       OPENBLAS_NUM_THREADS: 2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Install dependencies
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -18,10 +18,10 @@ jobs:
     - uses: actions/checkout@v2
 
     # Install dependencies
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
The Github Action build is failing because scikit-learn 1.1 needs Python 3.8, see 
https://github.com/INRIA/scikit-learn-mooc/runs/6861980012?check_suite_focus=true with the error:
```
ERROR: No matching distribution found for scikit-learn>=1.1.1
```
I used Python 3.9 to have the same version as the Circle build.

Reminder:
- right now Circle is used for PRs (and be able to see the rendered HTML of the PR)
- Github Action is used to build from main and push the website to github-pages