### PR TITLE
Update plotly version

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -57,7 +57,7 @@ print()
 requirements = {'numpy': "1.16", 'scipy': "1.2", 'matplotlib': "3.0",
                 'sklearn': "1.1", 'pandas': "1",
                 'seaborn': "0.11",
-                'notebook': "5.7", 'plotly': "4.3"}
+                'notebook': "5.7", 'plotly': "5.10"}
 
 # now the dependencies
 for lib, required_version in list(requirements.items()):

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ dependencies:
   - pandas >= 1
   - matplotlib-base
   - seaborn
-  - plotly
+  - plotly >= 5.10
   - jupytext
   - beautifulsoup4
   - IPython

--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,5 @@ dependencies:
   - jupyterlab
   - notebook
   - jupytext
-  - plotly
+  - plotly >= 5.10
   - IPython

--- a/local-install-instructions.md
+++ b/local-install-instructions.md
@@ -50,7 +50,7 @@ Using python in /home/lesteve/miniconda3/envs/scikit-learn-course
 [ OK ] pandas version 1.2.0
 [ OK ] seaborn version 0.11.1
 [ OK ] notebook version 6.2.0
-[ OK ] plotly version 4.14.3
+[ OK ] plotly version 5.10.0
 ```
 
 ## Run Jupyter notebooks locally


### PR DESCRIPTION
Calling plotly on versions < v5.9.0 was raising a [FutureWarning](https://github.com/plotly/plotly.py/issues/3602) about pandas `DataFrame.append` method being deprecated (see for instance https://inria.github.io/scikit-learn-mooc/python_scripts/parameter_tuning_parallel_plot.html).

This PR updates plotly to the latest version to avoid such issue.