### PR TITLE
Test scikit-learn 1.2 release candidate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,18 +13,18 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - run: ./build_tools/circle/checksum_python_files.sh /tmp/checksum.txt
-      - restore_cache:
-          keys:
-            - v3-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v3-{{ .Branch }}
-            - v3-main
+      # - restore_cache:
+      #     keys:
+      #       - v3-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+      #       - v3-{{ .Branch }}
+      #       - v3-main
       - run:
           command: ./build_tools/circle/build_jupyter_book.sh
           no_output_timeout: 30m
-      - save_cache:
-          paths:
-            - jupyter-book/_build/.jupyter_cache
-          key: v3-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+      # - save_cache:
+      #     paths:
+      #       - jupyter-book/_build/.jupyter_cache
+      #     key: v3-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
       - store_artifacts:
           path: jupyter-book/_build/html
           destination: jupyter-book

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-scikit-learn>=1.1.1
+scikit-learn==1.2.0rc1
 pandas>=1
 matplotlib
 seaborn


### PR DESCRIPTION
Just to check nothing is badly broken. This is not meant to be merged.

Not sure how it will work with jupyter-cache. We may need to explicitly remove the jupyter-cache cache ...