### PR TITLE
Fix a small new line mistake

### DIFF
--- a/notebooks/03_categorical_pipeline.ipynb
+++ b/notebooks/03_categorical_pipeline.ipynb
@@ -425,6 +425,7 @@
     "- the original categories (before encoding) have an ordering;\n",
     "- the encoded categories follow the same ordering than the original\n",
     "  categories.\n",
+    "\n",
     "The **next exercise** highlights the issue of misusing `OrdinalEncoder` with\n",
     "a linear model.\n",
     "\n",


### PR DESCRIPTION
Hi there

First of all thanks for this course, its great

During reading the notebooks, I faced this line

![](https://user-images.githubusercontent.com/86428901/207033162-36cb328e-4cc6-4db5-87a2-5220acbea1bc.png)

and I thought maybe this highlighted line should be a new line (Due to markdown rule)

Update: I've noticed that in ReviewNB and GitHub, the newline showed correctly but in JupyterNotebook it is combined with previous line

Thanks