### PR TITLE
MAINT Introduce use of set_output to output dataframes

### DIFF
--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -172,9 +172,14 @@ data_train_scaled
 data_train_scaled = scaler.fit_transform(data_train)
 data_train_scaled
 
+# %% [markdown]
+# By default `StandardScaler` outputs a numpy array, but it is also possible to
+# set the output to be a pandas dataframe. This makes some data exploration
+# tasks easier, as it preserves the column names.
+
 # %%
-data_train_scaled = pd.DataFrame(data_train_scaled,
-                                 columns=data_train.columns)
+scaler = StandardScaler().set_output(transform="pandas")
+data_train_scaled = scaler.fit_transform(data_train)
 data_train_scaled.describe()
 
 # %% [markdown]


### PR DESCRIPTION
Pandas output with `set_output` API is available since v 1.2.

This PR introduces such a nice feature to the MOOC.