### PR TITLE
MAINT Update scikit-learn to v 1.2.1

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -58,7 +58,7 @@ requirements = {
     "numpy": "1.16",
     "scipy": "1.2",
     "matplotlib": "3.0",
-    "sklearn": "1.1",
+    "sklearn": "1.2",
     "pandas": "1",
     "seaborn": "0.11",
     "notebook": "5.7",

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: scikit-learn-course
 channels:
   - conda-forge
 dependencies:
-  - scikit-learn >= 1.1.1
+  - scikit-learn >= 1.2.1
   - pandas >= 1
   - matplotlib-base
   - seaborn

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - scikit-learn >= 1.1.1
+  - scikit-learn >= 1.2.1
   - pandas >= 1
   - matplotlib-base
   - seaborn

--- a/local-install-instructions.md
+++ b/local-install-instructions.md
@@ -46,7 +46,7 @@ Using python in /home/lesteve/miniconda3/envs/scikit-learn-course
 [ OK ] numpy version 1.19.5
 [ OK ] scipy version 1.6.0
 [ OK ] matplotlib version 3.3.3
-[ OK ] sklearn version 1.1.1
+[ OK ] sklearn version 1.2.1
 [ OK ] pandas version 1.2.0
 [ OK ] seaborn version 0.11.1
 [ OK ] notebook version 6.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-scikit-learn>=1.1.1
+scikit-learn>=1.2.1
 pandas>=1
 matplotlib
 seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=1.1.1
+scikit-learn>=1.2.1
 pandas>=1
 matplotlib
 seaborn


### PR DESCRIPTION
The sickit-learn v1.1.1 was introduced in #637.
Now the time has come to update to v1.2.1.
This is required for #674 and #683.