### PR TITLE
FIX use sparse_output parameter for OneHotEncoder

### DIFF
--- a/notebooks/03_categorical_pipeline.ipynb
+++ b/notebooks/03_categorical_pipeline.ipynb
@@ -276,7 +276,7 @@
    "source": [
     "from sklearn.preprocessing import OneHotEncoder\n",
     "\n",
-    "encoder = OneHotEncoder(sparse=False)\n",
+    "encoder = OneHotEncoder(sparse_output=False)\n",
     "education_encoded = encoder.fit_transform(education_column)\n",
     "education_encoded"
    ]
@@ -287,7 +287,7 @@
    "source": [
     "<div class=\"admonition note alert alert-info\">\n",
     "<p class=\"first admonition-title\" style=\"font-weight: bold;\">Note</p>\n",
-    "<p><tt class=\"docutils literal\">sparse=False</tt> is used in the <tt class=\"docutils literal\">OneHotEncoder</tt> for didactic purposes, namely\n",
+    "<p><tt class=\"docutils literal\">sparse_output=False</tt> is used in the <tt class=\"docutils literal\">OneHotEncoder</tt> for didactic purposes, namely\n",
     "easier visualization of the data.</p>\n",
     "<p class=\"last\">Sparse matrices are efficient data structures when most of your matrix\n",
     "elements are zero. They won't be covered in detail in this course. If you\n",

--- a/notebooks/03_categorical_pipeline_ex_02.ipynb
+++ b/notebooks/03_categorical_pipeline_ex_02.ipynb
@@ -139,7 +139,7 @@
     "\n",
     "Hint: `HistGradientBoostingClassifier` does not yet support sparse input\n",
     "data. You might want to use\n",
-    "`OneHotEncoder(handle_unknown=\"ignore\", sparse=False)` to force the use of a\n",
+    "`OneHotEncoder(handle_unknown=\"ignore\", sparse_output=False)` to force the use of a\n",
     "dense representation as a workaround."
    ]
   },

--- a/notebooks/03_categorical_pipeline_sol_02.ipynb
+++ b/notebooks/03_categorical_pipeline_sol_02.ipynb
@@ -178,7 +178,7 @@
     "\n",
     "Hint: `HistGradientBoostingClassifier` does not yet support sparse input\n",
     "data. You might want to use\n",
-    "`OneHotEncoder(handle_unknown=\"ignore\", sparse=False)` to force the use of a\n",
+    "`OneHotEncoder(handle_unknown=\"ignore\", sparse_output=False)` to force the use of a\n",
     "dense representation as a workaround."
    ]
   },
@@ -193,7 +193,7 @@
     "\n",
     "from sklearn.preprocessing import OneHotEncoder\n",
     "\n",
-    "categorical_preprocessor = OneHotEncoder(handle_unknown=\"ignore\", sparse=False)\n",
+    "categorical_preprocessor = OneHotEncoder(handle_unknown=\"ignore\", sparse_output=False)\n",
     "preprocessor = ColumnTransformer([\n",
     "    ('one-hot-encoder', categorical_preprocessor, categorical_columns)],\n",
     "    remainder=\"passthrough\")\n",

--- a/notebooks/linear_models_sol_04.ipynb
+++ b/notebooks/linear_models_sol_04.ipynb
@@ -380,7 +380,7 @@
     "from sklearn.preprocessing import OneHotEncoder\n",
     "\n",
     "single_feature = [\"CentralAir\"]\n",
-    "encoder = OneHotEncoder(sparse=False, dtype=np.int32)\n",
+    "encoder = OneHotEncoder(sparse_output=False, dtype=np.int32)\n",
     "X_trans = encoder.fit_transform(X_train[single_feature])\n",
     "X_trans = pd.DataFrame(\n",
     "    X_trans,\n",
@@ -427,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "encoder = OneHotEncoder(drop=\"first\", sparse=False, dtype=np.int32)\n",
+    "encoder = OneHotEncoder(drop=\"first\", sparse_output=False, dtype=np.int32)\n",
     "X_trans = encoder.fit_transform(X_train[single_feature])\n",
     "X_trans = pd.DataFrame(\n",
     "    X_trans,\n",

--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -172,7 +172,7 @@ print(
 # %%
 from sklearn.preprocessing import OneHotEncoder
 
-encoder = OneHotEncoder(sparse_output=output=False)
+encoder = OneHotEncoder(sparse_output=False)
 education_encoded = encoder.fit_transform(education_column)
 education_encoded
 

--- a/python_scripts/03_categorical_pipeline.py
+++ b/python_scripts/03_categorical_pipeline.py
@@ -172,13 +172,13 @@ print(
 # %%
 from sklearn.preprocessing import OneHotEncoder
 
-encoder = OneHotEncoder(sparse=False)
+encoder = OneHotEncoder(sparse_output=output=False)
 education_encoded = encoder.fit_transform(education_column)
 education_encoded
 
 # %% [markdown]
 # ```{note}
-# `sparse=False` is used in the `OneHotEncoder` for didactic purposes, namely
+# `sparse_output=False` is used in the `OneHotEncoder` for didactic purposes, namely
 # easier visualization of the data.
 #
 # Sparse matrices are efficient data structures when most of your matrix

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -102,7 +102,7 @@ print("The mean cross-validation accuracy is: "
 #
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use of a
+# `OneHotEncoder(handle_unknown="ignore", sparse_output=output=False)` to force the use of a
 # dense representation as a workaround.
 
 # %%

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -102,7 +102,7 @@ print("The mean cross-validation accuracy is: "
 #
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse_output=output=False)` to force the use of a
+# `OneHotEncoder(handle_unknown="ignore", sparse_output=False)` to force the use of a
 # dense representation as a workaround.
 
 # %%

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -126,7 +126,7 @@ print("The mean cross-validation accuracy is: "
 #
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse=False)` to force the use of a
+# `OneHotEncoder(handle_unknown="ignore", sparse_output=output=False)` to force the use of a
 # dense representation as a workaround.
 
 # %%
@@ -135,7 +135,7 @@ import time
 
 from sklearn.preprocessing import OneHotEncoder
 
-categorical_preprocessor = OneHotEncoder(handle_unknown="ignore", sparse=False)
+categorical_preprocessor = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
 preprocessor = ColumnTransformer([
     ('one-hot-encoder', categorical_preprocessor, categorical_columns)],
     remainder="passthrough")

--- a/python_scripts/03_categorical_pipeline_sol_02.py
+++ b/python_scripts/03_categorical_pipeline_sol_02.py
@@ -126,7 +126,7 @@ print("The mean cross-validation accuracy is: "
 #
 # Hint: `HistGradientBoostingClassifier` does not yet support sparse input
 # data. You might want to use
-# `OneHotEncoder(handle_unknown="ignore", sparse_output=output=False)` to force the use of a
+# `OneHotEncoder(handle_unknown="ignore", sparse_output=False)` to force the use of a
 # dense representation as a workaround.
 
 # %%

--- a/python_scripts/linear_models_sol_04.py
+++ b/python_scripts/linear_models_sol_04.py
@@ -208,7 +208,7 @@ X_train["CentralAir"]
 from sklearn.preprocessing import OneHotEncoder
 
 single_feature = ["CentralAir"]
-encoder = OneHotEncoder(sparse_output=output=False, dtype=np.int32)
+encoder = OneHotEncoder(sparse_output=False, dtype=np.int32)
 X_trans = encoder.fit_transform(X_train[single_feature])
 X_trans = pd.DataFrame(
     X_trans,

--- a/python_scripts/linear_models_sol_04.py
+++ b/python_scripts/linear_models_sol_04.py
@@ -208,7 +208,7 @@ X_train["CentralAir"]
 from sklearn.preprocessing import OneHotEncoder
 
 single_feature = ["CentralAir"]
-encoder = OneHotEncoder(sparse=False, dtype=np.int32)
+encoder = OneHotEncoder(sparse_output=output=False, dtype=np.int32)
 X_trans = encoder.fit_transform(X_train[single_feature])
 X_trans = pd.DataFrame(
     X_trans,
@@ -237,7 +237,7 @@ X_trans
 # binary categories.
 
 # %% tags=["solution"]
-encoder = OneHotEncoder(drop="first", sparse=False, dtype=np.int32)
+encoder = OneHotEncoder(drop="first", sparse_output=False, dtype=np.int32)
 X_trans = encoder.fit_transform(X_train[single_feature])
 X_trans = pd.DataFrame(
     X_trans,


### PR DESCRIPTION
`OneHotEncoder.sparse` is deprecated in favor of `OneHotEncoder.sparse_output`