### PR TITLE
MAINT Fix FutureWarnings for v1.2

### DIFF
--- a/python_scripts/ensemble_adaboost.py
+++ b/python_scripts/ensemble_adaboost.py
@@ -166,8 +166,8 @@ ensemble_weight
 # %%
 from sklearn.ensemble import AdaBoostClassifier
 
-base_estimator = DecisionTreeClassifier(max_depth=3, random_state=0)
-adaboost = AdaBoostClassifier(base_estimator=base_estimator,
+estimator = DecisionTreeClassifier(max_depth=3, random_state=0)
+adaboost = AdaBoostClassifier(estimator=estimator,
                               n_estimators=3, algorithm="SAMME",
                               random_state=0)
 adaboost.fit(data, target)

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -245,7 +245,7 @@ _ = plt.title("Predictions of bagged trees")
 from sklearn.ensemble import BaggingRegressor
 
 bagged_trees = BaggingRegressor(
-    base_estimator=DecisionTreeRegressor(max_depth=3),
+    estimator=DecisionTreeRegressor(max_depth=3),
     n_estimators=100,
 )
 _ = bagged_trees.fit(data_train, target_train)
@@ -333,11 +333,11 @@ polynomial_regressor = make_pipeline(
 # base models.
 #
 # The ensemble itself is simply built by passing the resulting pipeline as the
-# `base_estimator` parameter of the `BaggingRegressor` class:
+# `estimator` parameter of the `BaggingRegressor` class:
 
 # %%
 bagging = BaggingRegressor(
-    base_estimator=polynomial_regressor,
+    estimator=polynomial_regressor,
     n_estimators=100,
     random_state=0,
 )

--- a/python_scripts/ensemble_ex_01.py
+++ b/python_scripts/ensemble_ex_01.py
@@ -38,7 +38,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 
 # %% [markdown]
 # Create a `BaggingRegressor` and provide a `DecisionTreeRegressor`
-# to its parameter `base_estimator`. Train the regressor and evaluate its
+# to its parameter `estimator`. Train the regressor and evaluate its
 # generalization performance on the testing set using the mean absolute error.
 
 # %%

--- a/python_scripts/ensemble_introduction.py
+++ b/python_scripts/ensemble_introduction.py
@@ -102,9 +102,9 @@ print(f"R2 score obtained by cross-validation: "
 # %%time
 from sklearn.ensemble import BaggingRegressor
 
-base_estimator = DecisionTreeRegressor(random_state=0)
+estimator = DecisionTreeRegressor(random_state=0)
 bagging_regressor = BaggingRegressor(
-    base_estimator=base_estimator, n_estimators=20, random_state=0)
+    estimator=estimator, n_estimators=20, random_state=0)
 
 cv_results = cross_validate(bagging_regressor, data, target, n_jobs=2)
 scores = cv_results["test_score"]

--- a/python_scripts/ensemble_random_forest.py
+++ b/python_scripts/ensemble_random_forest.py
@@ -104,7 +104,7 @@ from sklearn.ensemble import BaggingClassifier
 bagged_trees = make_pipeline(
     preprocessor,
     BaggingClassifier(
-        base_estimator=DecisionTreeClassifier(random_state=0),
+        estimator=DecisionTreeClassifier(random_state=0),
         n_estimators=50, n_jobs=2, random_state=0,
     )
 )
@@ -121,7 +121,7 @@ print(f"Bagged decision tree classifier: "
 # better than the performance of a single tree.
 #
 # Now, we will use a random forest. You will observe that we do not need to
-# specify any `base_estimator` because the estimator is forced to be a decision
+# specify any `estimator` because the estimator is forced to be a decision
 # tree. Thus, we just specify the desired number of trees in the forest.
 
 # %%

--- a/python_scripts/ensemble_sol_01.py
+++ b/python_scripts/ensemble_sol_01.py
@@ -31,7 +31,7 @@ data_train, data_test, target_train, target_test = train_test_split(
 
 # %% [markdown]
 # Create a `BaggingRegressor` and provide a `DecisionTreeRegressor`
-# to its parameter `base_estimator`. Train the regressor and evaluate its
+# to its parameter `estimator`. Train the regressor and evaluate its
 # generalization performance on the testing set using the mean absolute error.
 
 # %%
@@ -41,7 +41,7 @@ from sklearn.tree import DecisionTreeRegressor
 from sklearn.ensemble import BaggingRegressor
 
 tree = DecisionTreeRegressor()
-bagging = BaggingRegressor(base_estimator=tree, n_jobs=2)
+bagging = BaggingRegressor(estimator=tree, n_jobs=2)
 bagging.fit(data_train, target_train)
 target_predicted = bagging.predict(data_test)
 print(f"Basic mean absolute error of the bagging regressor:\n"
@@ -72,7 +72,7 @@ param_grid = {
     "n_estimators": randint(10, 30),
     "max_samples": [0.5, 0.8, 1.0],
     "max_features": [0.5, 0.8, 1.0],
-    "base_estimator__max_depth": randint(3, 10),
+    "estimator__max_depth": randint(3, 10),
 }
 search = RandomizedSearchCV(
     bagging, param_grid, n_iter=20, scoring="neg_mean_absolute_error"

--- a/python_scripts/logistic_regression.py
+++ b/python_scripts/logistic_regression.py
@@ -80,7 +80,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LogisticRegression
 
 logistic_regression = make_pipeline(
-    StandardScaler(), LogisticRegression(penalty="none")
+    StandardScaler(), LogisticRegression(penalty=None)
 )
 logistic_regression.fit(data_train, target_train)
 accuracy = logistic_regression.score(data_test, target_test)


### PR DESCRIPTION
This PR solves two different `FutureWarning` being raised in v1.2:

FutureWarning: `base_estimator` was renamed to `estimator` in version 1.2 and will be removed in 1.4.

FutureWarning: `penalty='none'` has been deprecated in 1.2 and will be removed in 1.4.