### PR TITLE
Introduce use of plot_chance_level parameter

### DIFF
--- a/python_scripts/metrics_classification.py
+++ b/python_scripts/metrics_classification.py
@@ -394,7 +394,7 @@ _ = disp.ax_.set_title("Receiver Operating Characteristic curve")
 # performance obtained will be above this line.
 #
 # Instead of using a dummy classifier, you can use the parameter `plot_chance_level`
-# that the ROC and PR curves have implemented in scikit-learn:
+# available in the ROC and PR displays:
 
 # %%
 fig, axs = plt.subplots(ncols=2, nrows=1, figsize=(15, 7))
@@ -420,4 +420,4 @@ RocCurveDisplay.from_estimator(
     ax=axs[1],
 )
 
-_ = plt.suptitle("PR and ROC curves")
+_ = fig.suptitle("PR and ROC curves")

--- a/python_scripts/metrics_classification.py
+++ b/python_scripts/metrics_classification.py
@@ -392,3 +392,32 @@ _ = disp.ax_.set_title("Receiver Operating Characteristic curve")
 # the ROC-AUC is 0.5. Indeed, we show the generalization performance of a dummy
 # classifier (the orange dashed line) to show that even the worst generalization
 # performance obtained will be above this line.
+#
+# Instead of using a dummy classifier, you can use the parameter `plot_chance_level`
+# that the ROC and PR curves have implemented in scikit-learn:
+
+# %%
+fig, axs = plt.subplots(ncols=2, nrows=1, figsize=(15, 7))
+
+PrecisionRecallDisplay.from_estimator(
+    classifier,
+    data_test,
+    target_test,
+    pos_label="donated",
+    marker="+",
+    plot_chance_level=True,
+    chance_level_kw={"color": "tab:orange", "linestyle": "--"},
+    ax=axs[0],
+)
+RocCurveDisplay.from_estimator(
+    classifier,
+    data_test,
+    target_test,
+    pos_label="donated",
+    marker="+",
+    plot_chance_level=True,
+    chance_level_kw={"color": "tab:orange", "linestyle": "--"},
+    ax=axs[1],
+)
+
+_ = plt.suptitle("PR and ROC curves")


### PR DESCRIPTION
Since 1.3 we can use the `plot_chance_level` parameter for ROC and PR curves. I propose mentioning it at the end of the [Classification notebook](https://inria.github.io/scikit-learn-mooc/python_scripts/metrics_classification.html), so that we introduce the concept of chance level using a `DummyClassifier` before showing this feature.