### PR TITLE
Make the navbar scroll to the current page header

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,9 @@ matplotlib
 seaborn
 plotly
 jupyter-book>=0.11
+# Partial fix for the navbar scrollToActive behavior:
+# https://github.com/executablebooks/sphinx-book-theme/issues/541
+sphinx-book-theme @ git+https://github.com/ogrisel/sphinx-book-theme@fix-bd-docs-nav
 jupytext
 beautifulsoup4
 IPython


### PR DESCRIPTION
Deploy a partial fix for https://github.com/executablebooks/sphinx-book-theme/issues/541.

See discussion there for the details on what's missing.