### PR TITLE
MAINT Update scikit-learn to v 1.3

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -7,7 +7,9 @@ FAIL = "\x1b[41m[FAIL]\x1b[0m"
 try:
     from packaging.version import Version
 except ImportError:
-    print(FAIL, "'packaging' package not installed, install it with conda or pip")
+    print(
+        FAIL, "'packaging' package not installed, install it with conda or pip"
+    )
     sys.exit(1)
 
 # first check the python version
@@ -19,7 +21,10 @@ pyversion = Version(pyversion_str)
 if pyversion < Version("3.8"):
     print(
         FAIL,
-        "Python version 3.8 or above is required," f" but {pyversion_str} is installed.",
+        (
+            "Python version 3.8 or above is required,"
+            f" but {pyversion_str} is installed."
+        ),
     )
     sys.exit(1)
 print()
@@ -45,7 +50,10 @@ def import_version(pkg, min_ver, fail_msg=""):
         if Version(ver) < Version(min_ver):
             print(
                 FAIL,
-                f"{lib} version {min_ver} or higher required, but {ver} installed.",
+                (
+                    f"{lib} version {min_ver} or higher required, but"
+                    f" {ver} installed."
+                ),
             )
         else:
             print(OK, f"{pkg} version {ver}")
@@ -58,7 +66,7 @@ requirements = {
     "numpy": "1.16",
     "scipy": "1.2",
     "matplotlib": "3.0",
-    "sklearn": "1.2",
+    "sklearn": "1.3",
     "pandas": "1",
     "seaborn": "0.11",
     "notebook": "5.7",

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: scikit-learn-course
 channels:
   - conda-forge
 dependencies:
-  - scikit-learn >= 1.2.1
+  - scikit-learn >= 1.3
   - pandas >= 1
   - matplotlib-base
   - seaborn

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - scikit-learn >= 1.2.1
+  - scikit-learn >= 1.3
   - pandas >= 1
   - matplotlib-base
   - seaborn

--- a/local-install-instructions.md
+++ b/local-install-instructions.md
@@ -23,7 +23,7 @@ cd scikit-learn-mooc
 conda env create -f environment.yml
 ```
 
-## Check your install 
+## Check your install
 
 To make sure you have all the necessary packages installed, we **strongly
 recommend** you to execute the `check_env.py` script located at the root of
@@ -46,7 +46,7 @@ Using python in /home/lesteve/miniconda3/envs/scikit-learn-course
 [ OK ] numpy version 1.19.5
 [ OK ] scipy version 1.6.0
 [ OK ] matplotlib version 3.3.3
-[ OK ] sklearn version 1.2.1
+[ OK ] sklearn version 1.3
 [ OK ] pandas version 1.2.0
 [ OK ] seaborn version 0.11.1
 [ OK ] notebook version 6.2.0
@@ -63,4 +63,3 @@ jupyter notebook full-index.ipynb
 
 `full-index.ipynb` is an index file helping to navigate the notebooks.
 All the Jupyter notebooks are located in the `notebooks` folder.
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-scikit-learn>=1.2.1
+scikit-learn>=1.3
 pandas>=1
 matplotlib
 seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=1.2.1
+scikit-learn>=1.3
 pandas>=1
 matplotlib
 seaborn


### PR DESCRIPTION
PR #702 introduced `ValidationCruveDisplay` which requires v >= 1.3. This PR updates the requirements and, as a side effect, formats the code on those files.