### PR TITLE
Always pass a numpy array to ValidationCurveDisplay's `param_range`

### DIFF
--- a/python_scripts/cross_validation_validation_curve.py
+++ b/python_scripts/cross_validation_validation_curve.py
@@ -104,9 +104,10 @@ _ = plt.title("Train and test errors distribution via cross-validation")
 
 # %%
 # %%time
+import numpy as np
 from sklearn.model_selection import ValidationCurveDisplay
 
-max_depth = [1, 5, 10, 15, 20, 25]
+max_depth = np.array([1, 5, 10, 15, 20, 25])
 disp = ValidationCurveDisplay.from_estimator(
     regressor,
     data,


### PR DESCRIPTION
Follows #702. See also [#27311](https://github.com/scikit-learn/scikit-learn/pull/27311).

Passing a list to the `param_range` parameter in `ValidationCurveDisplay` may rise a hard to debug
```python-traceback
AttributeError: 'list' object has no attribute 'min'
```
if the spacing in the grid looks appropriate to use a "symlog" according to the current logic in the private function `_interval_max_min_ratio`.

I think that should be fixed in scikit-learn, but for the moment enforcing consistently passing numpy arrays may be a good fix.