### PR TITLE
ENH Expand contents related to Nystroem

### DIFF
--- a/python_scripts/linear_models_ex_02.py
+++ b/python_scripts/linear_models_ex_02.py
@@ -125,5 +125,9 @@ data.head()
 # %%
 # Write your code here.
 
+# %% [markdown]
+# How does the mean and std of the MAE for the Nystroem pipeline with optimal
+# `n_components` compare to the other previous models?
+
 # %%
 # Write your code here.

--- a/python_scripts/linear_models_ex_02.py
+++ b/python_scripts/linear_models_ex_02.py
@@ -93,11 +93,14 @@ data.head()
 # %% [markdown]
 # Transform the first 5 rows of the dataset and look at the column names. How
 # many features are generated at the output of the `PolynomialFeatures` step in
-# the previous pipeline? Check that the values for the new interactions features
-# are correct for a few of them.
+# the previous pipeline?
 
 # %%
 # Write your code here.
+
+# %% [markdown]
+# Check that the values for the new interaction features are correct for a few
+# of them.
 
 # %%
 # Write your code here.
@@ -126,7 +129,7 @@ data.head()
 # Write your code here.
 
 # %% [markdown]
-# How does the mean and std of the MAE for the Nystroem pipeline with optimal
+# How do the mean and std of the MAE for the Nystroem pipeline with optimal
 # `n_components` compare to the other previous models?
 
 # %%

--- a/python_scripts/linear_models_ex_02.py
+++ b/python_scripts/linear_models_ex_02.py
@@ -15,14 +15,14 @@
 # # 📝 Exercise M4.02
 #
 # In the previous notebook, we showed that we can add new features based on the
-# original feature to make the model more expressive, for instance `x ** 2` or `x ** 3`.
-# In that case we only used a single feature in `data`.
+# original feature `x` to make the model more expressive, for instance `x ** 2` or
+# `x ** 3`. In that case we only used a single feature in `data`.
 #
 # The aim of this notebook is to train a linear regression algorithm on a
 # dataset with more than a single feature. In such a "multi-dimensional" feature
-# space we can derive new features of the form `x1 * x2`, `x2 * x3`,
-# etc. Products of features are usually called "non-linear or
-# multiplicative interactions" between features.
+# space we can derive new features of the form `x1 * x2`, `x2 * x3`, etc.
+# Products of features are usually called "non-linear" or "multiplicative"
+# interactions between features.
 #
 # Feature engineering can be an important step of a model pipeline as long as
 # the new features are expected to be predictive. For instance, think of a
@@ -69,7 +69,9 @@ data.head()
 # Write your code here.
 
 # %% [markdown]
-# Compute the mean and std of the MAE in grams (g).
+# Compute the mean and std of the MAE in grams (g). Remember you have to revert
+# the sign introduced when metrics start with `neg_`, such as in
+# `"neg_mean_absolute_error"`.
 
 # %%
 # Write your code here.
@@ -78,16 +80,50 @@ data.head()
 # Now create a pipeline using `make_pipeline` consisting of a
 # `PolynomialFeatures` and a linear regression. Set `degree=2` and
 # `interaction_only=True` to the feature engineering step. Remember not to
-# include the bias to avoid redundancies with the linear's regression intercept.
+# include a "bias" feature (that is a constant-valued feature) to avoid
+# introducing a redundancy with the intercept of the subsequent linear
+# regression model.
 #
-# Use the same strategy as before to cross-validate such a pipeline.
+# You may want to use the `.set_output(transform="pandas")` method of the
+# pipeline to answer the next question.
 
 # %%
 # Write your code here.
 
 # %% [markdown]
-# Compute the mean and std of the MAE in grams (g) and compare with the results
+# Transform the first 5 rows of the dataset and look at the column names. How
+# many features are generated at the output of the `PolynomialFeatures` step in
+# the previous pipeline? Check that the values for the new interactions features
+# are correct for a few of them.
+
+# %%
+# Write your code here.
+
+# %%
+# Write your code here.
+
+# %% [markdown]
+# Use the same cross-validation strategy as done previously to estimate the mean
+# and std of the MAE in grams (g) for such a pipeline. Compare with the results
 # without feature engineering.
+
+# %%
+# Write your code here.
+
+# %% [markdown]
+#
+# Now let's try to build an alternative pipeline with an adjustable number of
+# intermediate features while keeping a similar predictive power. To do so, try
+# using the `Nystroem` transformer instead of `PolynomialFeatures`. Set the
+# kernel parameter to `"poly"` and `degree` to 2. Adjust the number of
+# components to be as small as possible while keeping a good cross-validation
+# performance.
+#
+# Hint: Use a `ValidationCurveDisplay` with `param_range = np.array([5, 10, 50,
+# 100])` to find the optimal `n_components`.
+
+# %%
+# Write your code here.
 
 # %%
 # Write your code here.

--- a/python_scripts/linear_models_sol_02.py
+++ b/python_scripts/linear_models_sol_02.py
@@ -9,8 +9,8 @@
 # # 📃 Solution for Exercise M4.02
 #
 # In the previous notebook, we showed that we can add new features based on the
-# original feature to make the model more expressive, for instance `x ** 2` or `x ** 3`.
-# In that case we only used a single feature in `data`.
+# original feature to make the model more expressive, for instance `x ** 2` or
+# `x ** 3`. In that case we only used a single feature in `data`.
 #
 # The aim of this notebook is to train a linear regression algorithm on a
 # dataset with more than a single feature. In such a "multi-dimensional" feature
@@ -76,7 +76,9 @@ cv_results = cross_validate(
 )
 
 # %% [markdown]
-# Compute the mean and std of the MAE in grams (g).
+# Compute the mean and std of the MAE in grams (g). Remember you have to revert
+# the sign introduced when metrics start with `neg_`, such as in
+# `"neg_mean_absolute_error"`.
 
 # %%
 # solution
@@ -94,7 +96,8 @@ print(
 # introducing a redundancy with the intercept of the subsequent linear
 # regression model.
 #
-# Use the same strategy as before to cross-validate such a pipeline.
+# You may want to use the `.set_output(transform="pandas")` method of the
+# pipeline to answer the next question.
 
 # %%
 # solution
@@ -106,8 +109,36 @@ poly_features = PolynomialFeatures(
 )
 linear_regression_interactions = make_pipeline(
     poly_features, linear_regression
-)
+).set_output(transform="pandas")
 
+# %% [markdown]
+# Transform the first 5 rows of the dataset and look at the column names. How
+# many features are generated at the output of the `PolynomialFeatures` step in
+# the previous pipeline? Check that the values for the new interactions features
+# are correct for a few of them.
+
+# %%
+# solution
+linear_regression_interactions.fit(data, target)
+linear_regression_interactions[0].transform(data[:5])
+
+# %% [markdown] tags=["solution"]
+# We observe that 3 features are generated, corresponding to the different
+# combinations of products of the 3 original features.
+
+# %%
+# solution
+culmen_length_first_sample = 181.0
+culmen_depth_first_sample = 18.7
+culmen_length_first_sample * culmen_depth_first_sample
+
+# %% [markdown]
+# Use the same cross-validation strategy as done previously to estimate the mean
+# and std of the MAE in grams (g) for such a pipeline. Compare with the results
+# without feature engineering.
+
+# %%
+# solution
 cv_results = cross_validate(
     linear_regression_interactions,
     data,
@@ -116,13 +147,6 @@ cv_results = cross_validate(
     scoring="neg_mean_absolute_error",
     n_jobs=2,
 )
-
-# %% [markdown]
-# Compute the mean and std of the MAE in grams (g) and compare with the results
-# without feature engineering.
-
-# %%
-# solution
 print(
     "Mean absolute error on testing set with interactions: "
     f"{-cv_results['test_score'].mean():.3f} ± "
@@ -130,7 +154,66 @@ print(
 )
 
 # %% [markdown] tags=["solution"]
-# We observe that the mean absolute error is lower and less spread with the
-# enriched features. In this case the "interactions" are indeed predictive. In
-# the following notebook we will see what happens when the enriched features are
-# non-predictive and how to deal with this case.
+# We observe that the MAE is lower and less spread with the enriched features.
+# In this case the "interactions" are indeed predictive. Later in this module we
+# will see what happens when the enriched features are non-predictive and how to
+# deal with this case.
+
+# %% [markdown]
+# Now let's try to see if we can build an alternatively pipeline with fewer
+# intermediate features while keeping a similar predictive power. To do so,
+# try using the `Nystroem` transformer instead of `PolynomialFeatures`. Set
+# the kernel parameter to `"poly"` and `degree` to 2. Adjust the number of
+# components to be as small as possible while keeping a good cross-validation
+# performance.
+#
+# Hint: Use a `ValidationCurveDisplay` with `param_range = np.array([1, 2, 5,
+# 10, 20, 50, 100])` to find the optimal `n_components`.
+
+# %%
+# solution
+import numpy as np
+
+from sklearn.kernel_approximation import Nystroem
+from sklearn.model_selection import ValidationCurveDisplay
+
+nystroem_regression = make_pipeline(
+    Nystroem(kernel="poly", degree=2, random_state=0),
+    linear_regression,
+)
+
+param_range = np.array([1, 2, 5, 10, 20, 50, 100])
+disp = ValidationCurveDisplay.from_estimator(
+    nystroem_regression,
+    data,
+    target,
+    param_name="nystroem__n_components",
+    param_range=param_range,
+    cv=10,
+    scoring="neg_mean_absolute_error",
+    negate_score=True,
+    std_display_style="errorbar",
+    n_jobs=2,
+)
+
+_ = disp.ax_.set(
+    xlabel="Number of components",
+    ylabel="Mean absolute error (g)",
+    title="Validation curve for Nystroem regression",
+)
+# %%
+# solution
+nystroem_regression.set_params(nystroem__n_components=10)
+cv_results = cross_validate(
+    nystroem_regression,
+    data,
+    target,
+    cv=10,
+    scoring="neg_mean_absolute_error",
+    n_jobs=2,
+)
+print(
+    "Mean absolute error on testing set with nystroem: "
+    f"{-cv_results['test_score'].mean():.3f} ± "
+    f"{cv_results['test_score'].std():.3f} g"
+)

--- a/python_scripts/linear_models_sol_02.py
+++ b/python_scripts/linear_models_sol_02.py
@@ -9,14 +9,14 @@
 # # 📃 Solution for Exercise M4.02
 #
 # In the previous notebook, we showed that we can add new features based on the
-# original feature to make the model more expressive, for instance `x ** 2` or
+# original feature `x` to make the model more expressive, for instance `x ** 2` or
 # `x ** 3`. In that case we only used a single feature in `data`.
 #
 # The aim of this notebook is to train a linear regression algorithm on a
 # dataset with more than a single feature. In such a "multi-dimensional" feature
-# space we can derive new features of the form `x1 * x2`, `x2 * x3`,
-# etc. Products of features are usually called "non-linear or
-# multiplicative interactions" between features.
+# space we can derive new features of the form `x1 * x2`, `x2 * x3`, etc.
+# Products of features are usually called "non-linear" or "multiplicative"
+# interactions between features.
 #
 # Feature engineering can be an important step of a model pipeline as long as
 # the new features are expected to be predictive. For instance, think of a

--- a/python_scripts/linear_models_sol_02.py
+++ b/python_scripts/linear_models_sol_02.py
@@ -217,6 +217,10 @@ _ = disp.ax_.set(
 # an overfitting model. The optimal number of Nyström components is around 10
 # for this dataset.
 
+# %% [markdown]
+# How does the mean and std of the MAE for the Nystroem pipeline with optimal
+# `n_components` compare to the other previous models?
+
 # %%
 # solution
 nystroem_regression.set_params(nystroem__n_components=10)

--- a/python_scripts/linear_models_sol_02.py
+++ b/python_scripts/linear_models_sol_02.py
@@ -127,6 +127,10 @@ linear_regression_interactions[0].transform(data[:5])
 # We observe that 3 features are generated, corresponding to the different
 # combinations of products of the 3 original features. So we have 6
 # intermediate features in total.
+#
+# For instance let's check that the value in the 1st row and the 5th column
+# (3384.7) is the product of the values at the first and third columns
+# (respectively 181.0 and 18.7) of the same row:
 
 # %%
 # solution

--- a/python_scripts/linear_models_sol_02.py
+++ b/python_scripts/linear_models_sol_02.py
@@ -114,8 +114,7 @@ linear_regression_interactions = make_pipeline(
 # %% [markdown]
 # Transform the first 5 rows of the dataset and look at the column names. How
 # many features are generated at the output of the `PolynomialFeatures` step in
-# the previous pipeline? Check that the values for the new interactions features
-# are correct for a few of them.
+# the previous pipeline?
 
 # %%
 # solution
@@ -123,12 +122,16 @@ linear_regression_interactions.fit(data, target)
 linear_regression_interactions[0].transform(data[:5])
 
 # %% [markdown] tags=["solution"]
-#
 # We observe that 3 features are generated, corresponding to the different
 # combinations of products of the 3 original features, i.e. we have 6
 # intermediate features in total. In general, given `p` original features, one
 # has `p * (p - 1) / 2` interactions.
-#
+
+# %% [markdown]
+# Check that the values for the new interaction features are correct for a few
+# of them.
+
+# %% [markdown] tags=["solution"]
 # Let's now check that the value in the 1st row and the 5th column (3384.7) is
 # the product of the values at the first and third columns (respectively 181.0
 # and 18.7) of the same row:
@@ -161,7 +164,6 @@ print(
 )
 
 # %% [markdown] tags=["solution"]
-#
 # We observe that the MAE is lower and less spread with the enriched features.
 # In this case the additional "interaction" features are indeed predictive.
 # Later in this module we will see what happens when the enriched features are
@@ -218,7 +220,7 @@ _ = disp.ax_.set(
 # for this dataset.
 
 # %% [markdown]
-# How does the mean and std of the MAE for the Nystroem pipeline with optimal
+# How do the mean and std of the MAE for the Nystroem pipeline with optimal
 # `n_components` compare to the other previous models?
 
 # %%

--- a/python_scripts/linear_models_sol_02.py
+++ b/python_scripts/linear_models_sol_02.py
@@ -125,12 +125,13 @@ linear_regression_interactions[0].transform(data[:5])
 # %% [markdown] tags=["solution"]
 #
 # We observe that 3 features are generated, corresponding to the different
-# combinations of products of the 3 original features. So we have 6
-# intermediate features in total.
+# combinations of products of the 3 original features, i.e. we have 6
+# intermediate features in total. In general, given `p` original features, one
+# has `p * (p - 1) / 2` interactions.
 #
-# For instance let's check that the value in the 1st row and the 5th column
-# (3384.7) is the product of the values at the first and third columns
-# (respectively 181.0 and 18.7) of the same row:
+# Let's now check that the value in the 1st row and the 5th column (3384.7) is
+# the product of the values at the first and third columns (respectively 181.0
+# and 18.7) of the same row:
 
 # %%
 # solution
@@ -209,6 +210,13 @@ _ = disp.ax_.set(
     ylabel="Mean absolute error (g)",
     title="Validation curve for Nystroem regression",
 )
+
+# %% [markdown] tags=["solution"]
+# In the validation curve above we can observe that a small number of components
+# leads to an underfitting model, whereas a large number of components leads to
+# an overfitting model. The optimal number of Nyström components is around 10
+# for this dataset.
+
 # %%
 # solution
 nystroem_regression.set_params(nystroem__n_components=10)
@@ -227,19 +235,12 @@ print(
 )
 
 # %% [markdown] tags=["solution"]
+# In this case we have a model with 10 features instead of 6, and which has
+# approximately the same prediction error as the model with interactions.
 #
-# So in the end we have a model with 10 features instead of 6, and the
-# prediction error is approximately the same.
-#
-# We also observe on the validation curve for the number of components of the
-# `Nystroem` transformer that the a too small number of components leads to an
-# underfitting model, while a too large number of components leads to an
-# overfitting model. The optimal number of Nyström components is around 10 for
-# this dataset.
-#
-# Note that if we had `p = 100` original features (instead of 3), the
-# `PolynomialFeatures` transformer would have generated `p * (p - 1) / 2 =
-# 4950` additional interaction features (so 5150 intermediate features in
+# Notice that if we had `p = 100` original features (instead of 3), the
+# `PolynomialFeatures` transformer would have generated `100 * (100 - 1) / 2 =
+# 4950` additional interaction features (so we would have 5050 features in
 # total). The resulting pipeline would have been much slower to train and
 # predict and would have had a much larger memory footprint. Furthermore, the
 # large number of interaction features would probably have resulted in an

--- a/python_scripts/linear_regression_non_linear_link.py
+++ b/python_scripts/linear_regression_non_linear_link.py
@@ -299,11 +299,17 @@ ax = sns.scatterplot(
 ax.plot(data, target_predicted)
 _ = ax.set_title(f"Mean squared error = {mse:.2f}")
 
+# %% [markdown]
+# `Nystroem` is a nice alternative to `PolynomialFeatures` that makes it
+# possible to keep the memory usage of the transformed dataset under control.
+# However, interpreting the meaning of the intermediate features can be
+# challenging.
+
 # %%
 from sklearn.kernel_approximation import Nystroem
 
 nystroem_regression = make_pipeline(
-    Nystroem(n_components=5),
+    Nystroem(kernel="poly", degree=3, n_components=5, random_state=0),
     LinearRegression(),
 )
 nystroem_regression.fit(data, target)


### PR DESCRIPTION
Addresses suggestions in [this commment](https://github.com/INRIA/scikit-learn-mooc/pull/696#discussion_r1309981324) by @ogrisel.

Side effects:
- adds reminder on reverting the sign in "neg_mean_absolute_error";
- fixes reference "in the following notebook" which is no longer true after the reordering;
- changes the behavior of Nystroem on the [Linear regression for a non-linear features-target relationship notebook](https://inria.github.io/scikit-learn-mooc/python_scripts/linear_regression_non_linear_link.html) to use a polynomial kernel, as it seems more pertinent to the contents of the notebook.