### PR TITLE
ENH Add explicit definitions for technical terms

### DIFF
--- a/jupyter-book/appendix/glossary.md
+++ b/jupyter-book/appendix/glossary.md
@@ -6,6 +6,14 @@ of this page.
 
 ## Main terms used in this course
 
+### API
+
+Refers to both the specific interfaces for estimators implemented in
+scikit-learn and the generalized conventions across types of estimators.
+
+In scikit-learn we try to adopt simple conventions and limit to a minimum the
+number of methods an object must implement.
+
 ### classification
 
 Type of problems where the goal is to [predict](#predict-prediction) a

--- a/jupyter-book/appendix/glossary.md
+++ b/jupyter-book/appendix/glossary.md
@@ -8,31 +8,25 @@ of this page.
 
 ### API
 
-Refers to both the specific interfaces for estimators implemented in
-scikit-learn and the generalized conventions across types of estimators.
+Acronym that stands for "Application Programming Interface". It can have a
+slightly different meaning in different contexts: in some cases it can be used
+to designate an online service that can be accessed by remote programs. In the
+context of an online service, the term "API" can be used both to designate the
+service itself, and the technical specification of the programming interface
+used by people who write client applications that connect to this service.
 
-The (public) API of scikit-learn is documented via the docstrings of public
-functions, classes and methods; and can be browsed online at:
+In the context of an offline library such as scikit-learn, it means the list of
+all (public) functions, classes and methods in the library, along with their
+documentation via docstrings. It and can be browsed online at:
 
 - https://scikit-learn.org/stable/modules/classes.html
 
 In scikit-learn we try to adopt simple conventions and limit to a minimum the
 number of methods an object must implement. Furthermore, scikit-learn tries to
-use consistent method names for different estimators of the same category:
-e.g. all transformers expose `fit`, `fit_transform` and `transform` methods
-and generally accept similar arguments of type and shapes for those methods.
+use consistent method names for different estimators of the same category: e.g.
+all transformers expose `fit`, `fit_transform` and `transform` methods and
+generally accept similar arguments of type and shapes for those methods.
 
-Note that, more generally, "API" is an acronym that stands for "Application
-Programming Interface". It can have a slightly different meaning in different
-contexts: in some cases it can be used to designate an online service that can be
-accessed by remote programs. In the context of an online service, the term "API"
-can be used both to designate the service itself, and the technical specification
-of the programming interface used by people who write client applications that
-connect to this service.
-
-In the context of an (offline) library such as scikit-learn, it just means the
-list of all (public) functions, classes and methods in the library, along with the
-specification of the accepted argument types.
 ### classification
 
 Type of problems where the goal is to [predict](#predict-prediction) a

--- a/jupyter-book/appendix/glossary.md
+++ b/jupyter-book/appendix/glossary.md
@@ -11,9 +11,28 @@ of this page.
 Refers to both the specific interfaces for estimators implemented in
 scikit-learn and the generalized conventions across types of estimators.
 
-In scikit-learn we try to adopt simple conventions and limit to a minimum the
-number of methods an object must implement.
+The (public) API of scikit-learn is documented via the docstrings of public
+functions, classes and methods; and can be browsed online at:
 
+- https://scikit-learn.org/stable/modules/classes.html
+
+In scikit-learn we try to adopt simple conventions and limit to a minimum the
+number of methods an object must implement. Furthermore, scikit-learn tries to
+use consistent method names for different estimators of the same category:
+e.g. all transformers expose `fit`, `fit_transform` and `transform` methods
+and generally accept similar arguments of type and shapes for those methods.
+
+Note that, more generally, "API" is an acronym that stands for "Application
+Programming Interface". It can have a slightly different meaning in different
+contexts: in some cases it can be used to designate an online service that can be
+accessed by remote programs. In the context of an online service, the term "API"
+can be used both to designate the service itself, and the technical specification
+of the programming interface used by people who write client applications that
+connect to this service.
+
+In the context of an (offline) library such as scikit-learn, it just means the
+list of all (public) functions, classes and methods in the library, along with the
+specification of the accepted argument types.
 ### classification
 
 Type of problems where the goal is to [predict](#predict-prediction) a

--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -11,20 +11,23 @@
 # In this notebook, we present how to build predictive models on tabular
 # datasets, with only numerical features.
 #
-# In particular we will highlight:
+# In particular we highlight:
 #
 # * the scikit-learn API: `.fit(X, y)`/`.predict(X)`/`.score(X, y)`;
 # * how to evaluate the generalization performance of a model with a train-test
 #   split.
 #
+# Here API stands for "Application Programming Interface" and refers to a set of
+# conventions to build self-consistent software. Notice that you can visit the
+# Glossary for more info on technical jargon.
+#
 # ## Loading the dataset with Pandas
 #
-# We will use the same dataset "adult_census" described in the previous
-# notebook. For more details about the dataset see
-# <http://www.openml.org/d/1590>.
+# We use the "adult_census" dataset described in the previous notebook. For more
+# details about the dataset see <http://www.openml.org/d/1590>.
 #
 # Numerical data is the most natural type of data used in machine learning and
-# can (almost) directly be fed into predictive models. We will load a subset of
+# can (almost) directly be fed into predictive models. Here we load a subset of
 # the original data with only the numerical columns.
 
 # %%
@@ -56,7 +59,7 @@ data = adult_census.drop(columns=[target_name])
 data.head()
 
 # %% [markdown]
-# We can now linger on the variables, also denominated features, that we will
+# We can now linger on the variables, also denominated features, that we later
 # use to build our predictive model. In addition, we can also check how many
 # samples are available in our dataset.
 
@@ -72,7 +75,7 @@ print(
 # %% [markdown]
 # ## Fit a model and make predictions
 #
-# We will build a classification model using the "K-nearest neighbors" strategy.
+# We now build a classification model using the "K-nearest neighbors" strategy.
 # To predict the target of a new sample, a k-nearest neighbors takes into
 # account its `k` closest samples in the training set and predicts the majority
 # target of these samples.
@@ -97,10 +100,11 @@ _ = model.fit(data, target)
 #
 # ![Predictor fit diagram](../figures/api_diagram-predictor.fit.svg)
 #
+# In scikit-learn an object that has a `fit` method is called an **estimator**.
 # The method `fit` is composed of two elements: (i) a **learning algorithm** and
 # (ii) some **model states**. The learning algorithm takes the training data and
-# training target as input and sets the model states. These model states will be
-# used later to either predict (for classifiers and regressors) or transform
+# training target as input and sets the model states. These model states are
+# later used to either predict (for classifiers and regressors) or transform
 # data (for transformers).
 #
 # Both the learning algorithm and the type of model states are specific to each
@@ -120,17 +124,18 @@ _ = model.fit(data, target)
 target_predicted = model.predict(data)
 
 # %% [markdown]
-# We can illustrate the prediction mechanism as follows:
+# An estimator (an object with a `fit` method) with a `predict` method is called
+# a **predictor**. We can illustrate the prediction mechanism as follows:
 #
 # ![Predictor predict diagram](../figures/api_diagram-predictor.predict.svg)
 #
-# To predict, a model uses a **prediction function** that will use the input
-# data together with the model states. As for the learning algorithm and the
-# model states, the prediction function is specific for each type of model.
+# To predict, a model uses a **prediction function** that uses the input data
+# together with the model states. As for the learning algorithm and the model
+# states, the prediction function is specific for each type of model.
 
 # %% [markdown]
 # Let's now have a look at the computed predictions. For the sake of simplicity,
-# we will look at the five first predicted targets.
+# we look at the five first predicted targets.
 
 # %%
 target_predicted[:5]
@@ -214,7 +219,9 @@ model_name = model.__class__.__name__
 print(f"The test accuracy using a {model_name} is {accuracy:.3f}")
 
 # %% [markdown]
-# Let's check the underlying mechanism when the `score` method is called:
+# We use the generic term **model** for objects whose goodness of fit can be
+# measured using the `score` method. Let's check the underlying mechanism when
+# calling `score`:
 #
 # ![Predictor score diagram](../figures/api_diagram-predictor.score.svg)
 #
@@ -234,13 +241,13 @@ print(f"The test accuracy using a {model_name} is {accuracy:.3f}")
 
 # %% [markdown]
 # ```{note}
-# In this MOOC, we will refer to **generalization performance** of a model when
-# referring to the test score or test error obtained by comparing the
-# prediction of a model and the true targets. Equivalent terms for
-# **generalization performance** are predictive performance and statistical
-# performance. We will refer to **computational performance** of a predictive
-# model when assessing the computational costs of training a predictive model
-# or using it to make predictions.
+# In this MOOC, we refer to **generalization performance** of a model when
+# referring to the test score or test error obtained by comparing the prediction
+# of a model and the true targets. Equivalent terms for **generalization
+# performance** are predictive performance and statistical performance. We refer
+# to **computational performance** of a predictive model when assessing the
+# computational costs of training a predictive model or using it to make
+# predictions.
 # ```
 
 # %% [markdown]
@@ -252,4 +259,5 @@ print(f"The test accuracy using a {model_name} is {accuracy:.3f}")
 # * evaluated its generalization performance on the testing data;
 # * introduced the scikit-learn API `.fit(X, y)` (to train a model),
 #   `.predict(X)` (to make predictions) and `.score(X, y)` (to evaluate a
-#   model).
+#   model);
+# * introduced the jargon for estimator, predictor and model.

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -166,6 +166,9 @@ data_train_scaled
 # `fit` and then `transform`.
 #
 # ![Transformer fit_transform diagram](../figures/api_diagram-transformer.fit_transform.svg)
+#
+# In scikit-learn jargon, a **transformer** is defined as an estimator (an
+# object with a `fit` method) supporting `transform` or `fit_transform`.
 
 # %%
 data_train_scaled = scaler.fit_transform(data_train)

--- a/python_scripts/cross_validation_validation_curve.py
+++ b/python_scripts/cross_validation_validation_curve.py
@@ -12,8 +12,8 @@
 # and how it helps us quantify the training and testing errors as well as their
 # fluctuations.
 #
-# In this notebook, we will put these two errors into perspective and show how
-# they can help us know if our model generalizes, overfits, or underfits.
+# In this notebook, we put these two errors into perspective and show how they
+# can help us know if our model generalizes, overfits, or underfits.
 #
 # Let's first load the data and create the same model as in the previous
 # notebook.
@@ -40,7 +40,7 @@ regressor = DecisionTreeRegressor()
 # ## Overfitting vs. underfitting
 #
 # To better understand the generalization performance of our model and maybe
-# find insights on how to improve it, we will compare the testing error with the
+# find insights on how to improve it, we compare the testing error with the
 # training error. Thus, we need to compute the error on the training set, which
 # is possible using the `cross_validate` function.
 
@@ -93,13 +93,20 @@ _ = plt.title("Train and test errors distribution via cross-validation")
 #
 # ## Validation curve
 #
+# We call **hyperparameters** those parameters that potentially impact the
+# result of the learning and subsequent predictions of a predictor. For example:
+#
+# - the number of neighbors in a k-nearest neighbor model;
+#
+# - the degree of the polynomial.
+#
 # Some model hyperparameters are usually the key to go from a model that
 # underfits to a model that overfits, hopefully going through a region were we
 # can get a good balance between the two. We can acquire knowledge by plotting a
 # curve called the validation curve. This curve can also be applied to the above
 # experiment and varies the value of a hyperparameter.
 #
-# For the decision tree, the `max_depth` parameter is used to control the
+# For the decision tree, the `max_depth` hyperparameter is used to control the
 # tradeoff between under-fitting and over-fitting.
 
 # %%
@@ -165,4 +172,4 @@ _ = disp.ax_.set(
 #
 # * how to identify whether a model is generalizing, overfitting, or
 #   underfitting;
-# * how to check influence of a hyperparameter on the tradeoff underfit/overfit.
+# * how to check influence of a hyperparameter on the underfit/overfit tradeoff.

--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -270,7 +270,7 @@ _ = plt.title("Predictions of bagged trees")
 #
 # ## Bagging in scikit-learn
 #
-# Scikit-learn implements the bagging procedure as a "meta-estimator", that is
+# Scikit-learn implements the bagging procedure as a **meta-estimator**, that is,
 # an estimator that wraps another estimator: it takes a base model that is
 # cloned several times and trained independently on each bootstrap sample.
 #

--- a/python_scripts/parameter_tuning_manual.py
+++ b/python_scripts/parameter_tuning_manual.py
@@ -8,26 +8,19 @@
 # %% [markdown]
 # # Set and get hyperparameters in scikit-learn
 #
-# The process of learning a predictive model is driven by a set of internal
-# parameters and a set of training data. These internal parameters are called
-# hyperparameters and are specific for each family of models. In addition, a
-# specific set of hyperparameters are optimal for a specific dataset and thus
-# they need to be optimized.
-#
-# ```{note}
-# In this notebook we will use the words "hyperparameters" and "parameters"
-# interchangeably.
-# ```
+# Recall that hyperparameters refer to the parameters that control the learning
+# process of a predictive model and are specific for each family of models. In
+# addition, the optimal set of hyperparameters is specific to each dataset and
+# thus they always need to be optimized.
 #
 # This notebook shows how one can get and set the value of a hyperparameter in a
-# scikit-learn estimator. We recall that hyperparameters refer to the parameter
-# that will control the learning process.
+# scikit-learn estimator.
 #
 # They should not be confused with the fitted parameters, resulting from the
 # training. These fitted parameters are recognizable in scikit-learn because
 # they are spelled with a final underscore `_`, for instance `model.coef_`.
 #
-# We will start by loading the adult census dataset and only use the numerical
+# We start by loading the adult census dataset and only use the numerical
 # features.
 
 # %%
@@ -83,7 +76,7 @@ print(
 
 # %% [markdown]
 # We created a model with the default `C` value that is equal to 1. If we wanted
-# to use a different `C` parameter we could have done so when we created the
+# to use a different `C` hyperparameter we could have done so when we created the
 # `LogisticRegression` object with something like `LogisticRegression(C=1e-3)`.
 #
 # ```{note}
@@ -92,9 +85,9 @@ print(
 # Be aware that we will focus on linear models in an upcoming module.
 # ```
 #
-# We can also change the parameter of a model after it has been created with the
-# `set_params` method, which is available for all scikit-learn estimators. For
-# example, we can set `C=1e-3`, fit and evaluate the model:
+# We can also change the hyperparameter of a model after it has been created
+# with the `set_params` method, which is available for all scikit-learn
+# estimators. For example, we can set `C=1e-3`, fit and evaluate the model:
 
 # %%
 model.set_params(classifier__C=1e-3)
@@ -106,23 +99,23 @@ print(
 )
 
 # %% [markdown]
-# When the model of interest is a `Pipeline`, the parameter names are of the
-# form `<model_name>__<parameter_name>` (note the double underscore in the
-# middle). In our case, `classifier` comes from the `Pipeline` definition and
-# `C` is the parameter name of `LogisticRegression`.
+# When the model of interest is a `Pipeline`, the hyperparameter names are of
+# the form `<model_name>__<hyperparameter_name>` (note the double underscore in
+# the middle). In our case, `classifier` comes from the `Pipeline` definition
+# and `C` is the hyperparameter name of `LogisticRegression`.
 #
 # In general, you can use the `get_params` method on scikit-learn models to list
-# all the parameters with their values. For example, if you want to get all the
-# parameter names, you can use:
+# all the hyperparameters with their values. For example, if you want to get all
+# the hyperparameter names, you can use:
 
 # %%
 for parameter in model.get_params():
     print(parameter)
 
 # %% [markdown]
-# `.get_params()` returns a `dict` whose keys are the parameter names and whose
-# values are the parameter values. If you want to get the value of a single
-# parameter, for example `classifier__C`, you can use:
+# `.get_params()` returns a `dict` whose keys are the hyperparameter names and
+# whose values are the hyperparameter values. If you want to get the value of a
+# single hyperparameter, for example `classifier__C`, you can use:
 
 # %%
 model.get_params()["classifier__C"]
@@ -158,5 +151,5 @@ for C in [1e-3, 1e-2, 1e-1, 1, 10]:
 # %% [markdown]
 # In this notebook we have seen:
 #
-# - how to use `get_params` and `set_params` to get the parameters of a model
+# - how to use `get_params` and `set_params` to get the hyperparameters of a model
 #   and set them.


### PR DESCRIPTION
Fixes #427.

Instead of introducing links, I added a phrase encouraging the use of the glossary and short definitions of:
- API
- estimator
- predictor
- transformer
- hyperparameter

Side effect: Prefer use of verbs in present mode.