### PR TITLE
Synchronize quizzes to use ValidationCurveDisplay

### DIFF
--- a/jupyter-book/ensemble/ensemble_wrap_up_quiz.md
+++ b/jupyter-book/ensemble/ensemble_wrap_up_quiz.md
@@ -85,7 +85,10 @@ _Select a single answer_
 Plot the validation curve of the `n_estimators` parameters defined by:
 
 ```python
-n_estimators = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000]
+import numpy as np
+
+
+n_estimators = np.array([1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000])
 ```
 
 ```{admonition} Question
@@ -182,7 +185,7 @@ Build a validation curve for a `sklearn.ensemble.HistGradientBoostingRegressor`
 varying `max_iter` as follows:
 
 ```python
-max_iter = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000]
+max_iters = np.array([1, 2, 5, 10, 20, 50, 100, 200, 500])
 ```
 
 We recall that `max_iter` corresponds to the number of trees in the boosted

--- a/jupyter-book/overfit/overfit_wrap_up_quiz.md
+++ b/jupyter-book/overfit/overfit_wrap_up_quiz.md
@@ -131,11 +131,14 @@ function to also compute the train score.
 
 +++
 
-We will now study the effect of the parameter `n_neighbors` on the train and
-test score using a validation curve. You can use the following parameter range:
+We now study the effect of the parameter `n_neighbors` on the train and test
+score using a validation curve. You can use the following parameter range:
 
 ```python
-param_range = [1, 2, 5, 10, 20, 50, 100, 200, 500]
+import numpy as np
+
+
+param_range = np.array([1, 2, 5, 10, 20, 50, 100, 200, 500])
 ```
 
 Also, use a 5-fold cross-validation and compute the balanced accuracy score
@@ -157,7 +160,7 @@ _Select a single answer_
 +++
 
 ```{admonition} Question
-Select the true affirmations stated below:
+Select the most correct of the affirmations stated below:
 
 - a) The model overfits for a range of `n_neighbors` values between 1 to 10
 - b) The model overfits for a range of `n_neighbors` values between 10 to 100
@@ -169,7 +172,7 @@ _Select a single answer_
 +++
 
 ```{admonition} Question
-Select which of the following statements are true:
+Select the most correct of the affirmations stated below:
 
 - a) The model best generalizes for a range of `n_neighbors` values between 1 to 10
 - b) The model best generalizes for a range of `n_neighbors` values between 10 to 100


### PR DESCRIPTION
Follows #712. See also #702.

Passing a list to the `param_range` in `ValidationCurveDisplay` may rise an `AttributeError`. Even if scikit-learn 1.3.1 will support lists for `param_range`, it is better to enforce consistently passing numpy arrays to validation curves.

Side effect: We revisited the interval suggested for `max_iters`.