### PR TITLE
Fix InvalidParameterError in plot_tree

### DIFF
--- a/python_scripts/trees_classification.py
+++ b/python_scripts/trees_classification.py
@@ -133,7 +133,7 @@ _, ax = plt.subplots(figsize=(8, 6))
 _ = plot_tree(
     tree,
     feature_names=culmen_columns,
-    class_names=tree.classes_,
+    class_names=tree.classes_.tolist(),
     impurity=False,
     ax=ax,
 )

--- a/python_scripts/trees_regression.py
+++ b/python_scripts/trees_regression.py
@@ -144,7 +144,7 @@ _ = plt.title("Prediction function using a DecisionTreeRegressor")
 from sklearn.tree import plot_tree
 
 _, ax = plt.subplots(figsize=(8, 6))
-_ = plot_tree(tree, feature_names=feature_name, ax=ax)
+_ = plot_tree(tree, feature_names=[feature_name], ax=ax)
 
 # %% [markdown]
 # The threshold for our feature (flipper length) is 206.5 mm. The predicted

--- a/python_scripts/trees_sol_01.py
+++ b/python_scripts/trees_sol_01.py
@@ -86,7 +86,7 @@ _, ax = plt.subplots(figsize=(16, 12))
 _ = plot_tree(
     tree,
     feature_names=culmen_columns,
-    class_names=tree.classes_,
+    class_names=tree.classes_.tolist(),
     impurity=False,
     ax=ax,
 )


### PR DESCRIPTION
This PR solves
```python-traceback
InvalidParameterError: The 'feature_names' parameter of plot_tree must be an instance of 'list' or None. Got ... instead.
```