### PR TITLE
ENH Remove boilerplate from non-linear regression notebook

### DIFF
--- a/python_scripts/linear_regression_non_linear_link.py
+++ b/python_scripts/linear_regression_non_linear_link.py
@@ -281,7 +281,7 @@ spline_regression = make_pipeline(
 spline_regression
 
 # %%
-fit_score_plot_regression(spline_regression, title="Binned regression")
+fit_score_plot_regression(spline_regression, title="Spline regression")
 
 # %% [markdown]
 # `Nystroem` is a nice alternative to `PolynomialFeatures` that makes it

--- a/python_scripts/linear_regression_non_linear_link.py
+++ b/python_scripts/linear_regression_non_linear_link.py
@@ -17,10 +17,10 @@
 # step followed by a linear regression step can therefore be considered a
 # non-linear regression model as a whole.
 #
-# ```{tip}
-# `np.random.RandomState` allows to create a random number generator which can
-# be later used to get deterministic results.
-# ```
+# In this occasion we are not loading a dataset, but creating our own custom
+# data consisting of a single feature. The target is built as a cubic polynomial
+# on said feature. To make things a bit more challenging, we add some random
+# fluctuations to the target.
 
 # %%
 import numpy as np
@@ -36,10 +36,13 @@ noise = rng.randn(n_sample) * 0.3
 target = data**3 - 0.5 * data**2 + noise
 
 # %% [markdown]
-# ```{note}
+# ```{tip}
+# `np.random.RandomState` allows to create a random number generator which can
+# be later used to get deterministic results.
+# ```
+#
 # To ease the plotting, we create a pandas dataframe containing the data and
 # target:
-# ```
 
 # %%
 import pandas as pd


### PR DESCRIPTION
This PR:
- changes the title for consistency with the rest of the module
- adds preamble to building custom dataset;
- removes a "note" to reduce the number of highlights;
- defines a helper function to reduce boilerplate;
- displays the pipeline after the definition of each model;
- simplifies narrative on `PolynomialFeatures`;
- addresses [this suggestion](https://github.com/INRIA/scikit-learn-mooc/pull/711#discussion_r1322648681) to add splines to the discussion.
