### PR TITLE
MAINT Fix pandas version to 2.0 to avoid seaborn warning

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - scikit-learn >= 1.3
-  - pandas >= 1
+  - pandas = 2.0  # avoid seaborn warning
   - matplotlib-base
   - seaborn
   - plotly >= 5.10

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - scikit-learn >= 1.3
-  - pandas = 2.0  # avoid seaborn warning
+  - pandas == 2.0  # avoid seaborn warning
   - matplotlib-base
   - seaborn
   - plotly >= 5.10

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - scikit-learn >= 1.3
-  - pandas >= 1
+  - pandas = 2.0  # avoid seaborn warning
   - matplotlib-base
   - seaborn
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - scikit-learn >= 1.3
-  - pandas = 2.0  # avoid seaborn warning
+  - pandas == 2.0  # avoid seaborn warning
   - matplotlib-base
   - seaborn
   - jupyterlab

--- a/local-install-instructions.md
+++ b/local-install-instructions.md
@@ -47,7 +47,7 @@ Using python in /home/lesteve/miniconda3/envs/scikit-learn-course
 [ OK ] scipy version 1.6.0
 [ OK ] matplotlib version 3.3.3
 [ OK ] sklearn version 1.3
-[ OK ] pandas version 1.2.0
+[ OK ] pandas version 2.0
 [ OK ] seaborn version 0.11.1
 [ OK ] notebook version 6.2.0
 [ OK ] plotly version 5.10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 scikit-learn>=1.3
-pandas=2.0  # avoid seaborn warning
+pandas==2.0  # avoid seaborn warning
 matplotlib
 seaborn
 plotly

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 scikit-learn>=1.3
-pandas>=1
+pandas=2.0  # avoid seaborn warning
 matplotlib
 seaborn
 plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scikit-learn>=1.3
-pandas>=1
+pandas= 2.0  # avoid seaborn warning
 matplotlib
 seaborn
 plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scikit-learn>=1.3
-pandas= 2.0  # avoid seaborn warning
+pandas==2.0  # avoid seaborn warning
 matplotlib
 seaborn
 plotly


### PR DESCRIPTION
The version of pandas 2.1 is conflicting with seaborn. This is a quick fix until the issue is addressed on their side.

I did not modify check_env.py to keep the minimal required version of pandas to 1.0