### PR TITLE
Synchronize quizzes related to `predict_proba` and M4 refactoring

### DIFF
--- a/jupyter-book/linear_models/linear_models_quiz_m4_01.md
+++ b/jupyter-book/linear_models/linear_models_quiz_m4_01.md
@@ -17,7 +17,7 @@ _Select a single answer_
 
 ```{admonition} Question
 Is it possible to get a perfect fit (zero prediction error on the training set)
-with a linear classifier on a non-linearly separable dataset?
+with a linear classifier by itself on a non-linearly separable dataset?
 
 - a) yes
 - b) no

--- a/jupyter-book/linear_models/linear_models_quiz_m4_02.md
+++ b/jupyter-book/linear_models/linear_models_quiz_m4_02.md
@@ -36,3 +36,29 @@ The decision boundaries of a logistic regression model:
 
 _Select a single answer_
 ```
+
++++
+
+```{admonition} Question
+For a binary classification task, what is the shape of the array returned by the
+`predict_proba` method for 10 input samples?
+
+- a) (10,)
+- b) (10, 2)
+- c) (2, 10)
+
+_Select a single answer_
+```
+
++++
+
+```{admonition} Question
+In logistic regression's `predict_proba` method in scikit-learn, which of the
+following statements is true regarding the predicted probabilities?
+
+- a) The sum of probabilities across different classes for a given sample is always equal to 1.0.
+- b) The sum of probabilities across all samples for a given class is always equal to 1.0.
+- c) The sum of probabilities across all features for a given class is always equal to 1.0.
+
+_Select a single answer_
+```

--- a/jupyter-book/linear_models/linear_models_quiz_m4_03.md
+++ b/jupyter-book/linear_models/linear_models_quiz_m4_03.md
@@ -26,3 +26,16 @@ and `intercept_`?
 
 _Select a single answer_
 ```
+
++++
+
+```{admonition} Question
+Combining (one or more) feature engineering transformers in a single pipeline:
+
+- a) increases the expressivity of the model
+- b) ensures that models extrapolate accurately regardless of its distribution
+- c) may require tuning additional hyperparameters
+- d) inherently prevents any underfitting
+
+_Select all answers that apply_
+```

--- a/jupyter-book/linear_models/linear_models_quiz_m4_05.md
+++ b/jupyter-book/linear_models/linear_models_quiz_m4_05.md
@@ -5,7 +5,7 @@ By default, a [`LogisticRegression`](https://scikit-learn.org/stable/modules/gen
 
 - a) no penalty
 - b) a penalty that shrinks the magnitude of the weights towards zero (also called "l2 penalty")
-- c) a penalty that sets some weights exactly to zero (also called "l1 penalty")
+- c) a penalty that ensures all weights are equal
 
 _Select a single answer_
 ```
@@ -18,6 +18,18 @@ The parameter `C` in a logistic regression is:
 - a) similar to the parameter `alpha` in a ridge regressor
 - b) similar to `1 / alpha` where `alpha` is the parameter of a ridge regressor
 - c) not controlling the regularization
+
+_Select a single answer_
+```
+
++++
+
+```{admonition} Question
+In logistic regression, increasing the regularization strength makes the model:
+
+- a) more likely to overfit to the training data
+- b) more flexible, fitting closely to the training data
+- c) less complex, potentially underfitting the training data
 
 _Select a single answer_
 ```


### PR DESCRIPTION
This PR:
- modifies Q2 in M4.01 to be more consistent with later-introduced contents;
- introduces 2 questions in M4.02 related to the content introduced in #723;
- adds question in M4.03 regarding feature engineering in general;
- modifies M4.05 to address [this comment](https://github.com/INRIA/scikit-learn-mooc/pull/710#discussion_r1340333330);
- adds a question in M4.05 regarding the underfitting-overfitting trade-off in logistic regression `C`.