### PR TITLE
MAINT Fix broken sphinx-book-theme reference in CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ plotly
 jupyter-book>=0.11
 # Partial fix for the navbar scrollToActive behavior:
 # https://github.com/executablebooks/sphinx-book-theme/issues/541
-sphinx-book-theme @ git+executablebooks/sphinx-book-theme@aca0f7fd39314ec3283f1ff798b4bf8ee9b49cad
+sphinx-book-theme @ git+https://github.com/executablebooks/sphinx-book-theme.git@aca0f7fd39314ec3283f1ff798b4bf8ee9b49cad
 jupytext
 beautifulsoup4
 IPython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ plotly
 jupyter-book>=0.11
 # Partial fix for the navbar scrollToActive behavior:
 # https://github.com/executablebooks/sphinx-book-theme/issues/541
-sphinx-book-theme @ git+https://github.com/ogrisel/sphinx-book-theme@fix-bd-docs-nav
+sphinx-book-theme @ git+https://github.com/executablebooks/sphinx-book-theme/commit/aca0f7fd39314ec3283f1ff798b4bf8ee9b49cad
 jupytext
 beautifulsoup4
 IPython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ plotly
 jupyter-book>=0.11
 # Partial fix for the navbar scrollToActive behavior:
 # https://github.com/executablebooks/sphinx-book-theme/issues/541
-sphinx-book-theme @ git+https://github.com/executablebooks/sphinx-book-theme/commit/aca0f7fd39314ec3283f1ff798b4bf8ee9b49cad
+sphinx-book-theme @ git+executablebooks/sphinx-book-theme@aca0f7fd39314ec3283f1ff798b4bf8ee9b49cad
 jupytext
 beautifulsoup4
 IPython


### PR DESCRIPTION
The CI was running on the branch related the PR https://github.com/executablebooks/sphinx-book-theme/pull/754. When the branch was erased by the merge, the CI got broken.

This PR fixes the issue by pointing to the respective commit.