### PR TITLE
MAINT use actions/cache@v3 instead of v2

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
         pip install -r requirements-dev.txt
 
     - name: Cache jupyter-cache folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: jupyter-cache
       with:


### PR DESCRIPTION
When running the gh-pages deployment one gets the following warning:

```
deploy-gh-pages
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

```