### PR TITLE
MAINT Remove sparse_threshold

### DIFF
--- a/python_scripts/parameter_tuning_ex_02.py
+++ b/python_scripts/parameter_tuning_ex_02.py
@@ -53,7 +53,6 @@ preprocessor = ColumnTransformer(
         )
     ],
     remainder="passthrough",
-    sparse_threshold=0,
 )
 
 from sklearn.ensemble import HistGradientBoostingClassifier

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -89,7 +89,6 @@ from sklearn.compose import ColumnTransformer
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    sparse_threshold=0,
 )
 
 # %% [markdown]

--- a/python_scripts/parameter_tuning_nested.py
+++ b/python_scripts/parameter_tuning_nested.py
@@ -56,7 +56,6 @@ preprocessor = ColumnTransformer(
         ("cat_preprocessor", categorical_preprocessor, categorical_columns),
     ],
     remainder="passthrough",
-    sparse_threshold=0,
 )
 
 # %%

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -73,7 +73,6 @@ categorical_preprocessor = OrdinalEncoder(
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    sparse_threshold=0,
 )
 
 # %%

--- a/python_scripts/parameter_tuning_sol_02.py
+++ b/python_scripts/parameter_tuning_sol_02.py
@@ -47,7 +47,6 @@ preprocessor = ColumnTransformer(
         )
     ],
     remainder="passthrough",
-    sparse_threshold=0,
 )
 
 from sklearn.ensemble import HistGradientBoostingClassifier


### PR DESCRIPTION
Fixes #476.

The fact that `HistGradientBoostingClassifier` does not support sparse data is not a problem when used along with `OrdinalEncoder` inside a pipelines. This PR simplifies the code by removing the `sparse_threshold=0` parameter from the `ColumnTransformer`.