### PR TITLE
MAINT Revert fix pandas version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
 dependencies:
   - scikit-learn >= 1.3
-  - pandas == 2.0  # avoid seaborn warning
+  - pandas >= 1
   - matplotlib-base
-  - seaborn
+  - seaborn >= 0.13
   - plotly >= 5.10
   - jupytext
   - beautifulsoup4

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,9 @@ channels:
 
 dependencies:
   - scikit-learn >= 1.3
-  - pandas == 2.0  # avoid seaborn warning
+  - pandas >= 1
   - matplotlib-base
-  - seaborn
+  - seaborn >= 0.13
   - jupyterlab
   - notebook
   - plotly >= 5.10

--- a/local-install-instructions.md
+++ b/local-install-instructions.md
@@ -48,7 +48,7 @@ Using python in /home/lesteve/miniconda3/envs/scikit-learn-course
 [ OK ] matplotlib version 3.3.3
 [ OK ] sklearn version 1.3
 [ OK ] pandas version 2.0
-[ OK ] seaborn version 0.11.1
+[ OK ] seaborn version 0.13
 [ OK ] notebook version 6.2.0
 [ OK ] plotly version 5.10.0
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 scikit-learn>=1.3
-pandas==2.0  # avoid seaborn warning
+pandas >= 1
 matplotlib
-seaborn
+seaborn >= 0.13
 plotly
 jupyter-book>=0.11
 # Partial fix for the navbar scrollToActive behavior:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 scikit-learn>=1.3
-pandas==2.0  # avoid seaborn warning
+pandas >= 1
 matplotlib
-seaborn
+seaborn >= 0.13
 plotly
 jupyterlab
 notebook


### PR DESCRIPTION
As mentioned in https://github.com/INRIA/scikit-learn-mooc/pull/727#issuecomment-1776912757, the `FutureWarning` being raised by seaborn was fixed in v0.13.

This PR unpins the pandas version and updates the seaborn version instead.