### PR TITLE
MAINT Update wrap-up quiz M5

### DIFF
--- a/jupyter-book/trees/trees_wrap_up_quiz.md
+++ b/jupyter-book/trees/trees_wrap_up_quiz.md
@@ -7,7 +7,10 @@ Open the dataset `ames_housing_no_missing.csv` with the following command:
 ```python
 import pandas as pd
 
-ames_housing = pd.read_csv("../datasets/ames_housing_no_missing.csv")
+ames_housing = pd.read_csv(
+    "../datasets/ames_housing_no_missing.csv",
+    na_filter=False,  # required for pandas>2.0
+)
 target_name = "SalePrice"
 data = ames_housing.drop(columns=target_name)
 target = ames_housing[target_name]


### PR DESCRIPTION
@lfarhi noticed a degrade of the performance of the tree model at the end of wrap-up quiz M5. The reason is that Pandas>2.0 converts `None` into `NaN`, which broke the pipeline with ordinal encoding. This PR fixes the issue.