### PR TITLE
Add info about the certification

### DIFF
--- a/jupyter-book/_config.yml
+++ b/jupyter-book/_config.yml
@@ -46,12 +46,14 @@ html:
   extra_footer: |
     <div>
       <div class="mooc_add">
-       <a href="https://www.fun-mooc.fr/en/courses/machine-learning-python-scikit-learn">Join the full MOOC for better learning!</a>
+       <a href="https://www.fun-mooc.fr/en/courses/machine-learning-python-scikit-learn">Join the full MOOC experience</a>
+       <a href="https://certification.probabl.ai/">Get officially certified!</a>
       </div>
       Brought to you under a <a href="https://github.com/INRIA/scikit-learn-mooc/blob/main/LICENSE">CC-BY License</a> by
       <a href="https://learninglab.inria.fr">Inria Learning Lab</a>,
       <a href="https://scikit-learn.fondation-inria.fr">scikit-learn @ La Fondation Inria</a>,
       <a href="https://www.inria-academy.fr/formation/scikit-learn-la-boite-a-outils-de-lapprentissage-automatique/">Inria Academy</a>,
+      <a href="https://probabl.ai/">probabl</a>,
       with many thanks to the <a href="https://scikit-learn.org">scikit-learn</a> community as a whole!
     </div>
 

--- a/jupyter-book/_static/sklearn_mooc.css
+++ b/jupyter-book/_static/sklearn_mooc.css
@@ -27,17 +27,17 @@ p[aria-level="2"] {
     font-weight: bold;
 }
 
-/* The add to join the MOOC */
+/* The adds in the landing page */
 
 div.mooc_add {
     display: table;
 }
 
 div.mooc_add a {
-    color: #813000;
+    color: #000000;
     display: block;
     border-radius: .4em;
-    background-color: #FFEBDD;
+    background-color: #F7931E;
     border: 1px solid #7b5a46;
     box-shadow: 1px 1px 1px #CA9875;
     padding: 5pt;
@@ -45,7 +45,7 @@ div.mooc_add a {
 
 @media screen and (min-width: 900px) {
     div.mooc_add {
-      width: 20ex;
+      width: 25ex;
       position: fixed;
       right: calc(5pt + .15 * (100vw - 900px)); 
       bottom: calc(5pt + max(0pt, .05*(100vh - 200px)));

--- a/jupyter-book/concluding_remarks.md
+++ b/jupyter-book/concluding_remarks.md
@@ -139,6 +139,11 @@ Let us give a few pointers on going further with machine learning.
       the solutions shared by the winners in the discussions is a
       good way to learn
 
+### Get certified
+
+- The [official scikit-learn certifications](https://certification.probabl.ai/)
+  are delivered by [probabl](https://probabl.ai/).
+
 ## Bringing value: The bigger picture beyond machine-learning
 
 We will now touch briefly how machine learning fits in wider questions,


### PR DESCRIPTION
Now that the official scikit-learn certification has been launched, more and more people will use the mooc as a reference to prepare themselves. It would then make sense if the certification points to the mooc and vice-versa, to improve legitimacy.