### PR TITLE
Rework cross_validation_time.py

### DIFF
--- a/python_scripts/cross_validation_time.py
+++ b/python_scripts/cross_validation_time.py
@@ -17,12 +17,13 @@
 # (as in "independent and identically distributed random variables").
 # ```
 #
-# This assumption is usually violated when dealing with time series. A sample
-# depends on past information, in other words, the generative process has
-# memory or is influenced by past data.
+# This assumption is usually violated in time series, where each sample can be
+# influenced by previous samples (both their feature and target values) in an
+# inherently ordered sequence.
 #
-# We will take an example to highlight such issues with non-i.i.d. data in the
-# previous cross-validation strategies presented. We are going to load financial
+# In this notebook we demonstrate the issues that arise when using the
+# cross-validation strategies we have presented so far, along with non-i.i.d.
+# data. For such purpose we load financial
 # quotations from some energy companies.
 
 # %%
@@ -60,8 +61,6 @@ _ = plt.title("Stock values over time")
 # Here, we want to predict the quotation of Chevron using all other energy
 # companies' quotes. To make explanatory plots, we first use a train-test split
 # and then we evaluate other cross-validation methods.
-#
-
 
 # %%
 from sklearn.model_selection import train_test_split
@@ -71,7 +70,7 @@ data_train, data_test, target_train, target_test = train_test_split(
     data, target, shuffle=True, random_state=0
 )
 
-# Correct the order of the data to maintain the time order
+# Shuffling breaks the index order, but we still want it to be time-ordered
 data_train.sort_index(ascending=True, inplace=True)
 data_test.sort_index(ascending=True, inplace=True)
 target_train.sort_index(ascending=True, inplace=True)
@@ -80,7 +79,7 @@ target_test.sort_index(ascending=True, inplace=True)
 
 # %% [markdown]
 # We will use a decision tree regressor that we expect to overfit and thus not
-# generalize to unseen data of the time series. We will use a `ShuffleSplit` cross-validation to
+# generalize to unseen data. We use a `ShuffleSplit` cross-validation to
 # check the generalization performance of our model.
 #
 # Let's first define our model
@@ -99,7 +98,7 @@ from sklearn.model_selection import ShuffleSplit
 cv = ShuffleSplit(random_state=0)
 
 # %% [markdown]
-# Finally, we perform the evaluation using the `ShuffleSplit` cross-validation
+# We then perform the evaluation using the `ShuffleSplit` strategy.
 
 # %%
 from sklearn.model_selection import cross_val_score
@@ -112,10 +111,10 @@ print(f"The mean R2 is: {test_score.mean():.2f} ± {test_score.std():.2f}")
 # %% [markdown]
 # Surprisingly, we get outstanding generalization performance. We will
 # investigate and find the reason for such good results with a model that is
-# expected to fail. We previously mentioned that `ShuffleSplit` is an iterative
-# cross-validation scheme that shuffles data and split. 
-#  
-# We will simplify this
+# expected to fail. We previously mentioned that `ShuffleSplit` is a
+# cross-validation method that iteratively shuffles and splits the data.
+#
+# We can simplify the
 # procedure with a single split and plot the prediction. We can use
 # `train_test_split` for this purpose.
 
@@ -129,16 +128,13 @@ target_predicted = pd.Series(target_predicted, index=target_test.index)
 # Let's check the generalization performance of our model on this split.
 
 # %%
-from sklearn.metrics import r2_score, mean_squared_error
+from sklearn.metrics import r2_score
 
 test_score = r2_score(target_test, target_predicted)
-mse_score = mean_squared_error(target_test, target_predicted)
 print(f"The R2 on this single split is: {test_score:.2f}")
-print(f"The mean squared error on this single split is: {mse_score:.2f}")
-
 
 # %% [markdown]
-# Similarly, we obtain good results in terms of $R^2$ and the mean squared error. We will plot the
+# Similarly, we obtain good results in terms of $R^2$. We now plot the
 # training, testing and prediction samples.
 
 # %%
@@ -146,25 +142,26 @@ target_train.plot(label="Training")
 target_test.plot(label="Testing")
 target_predicted.plot(label="Prediction")
 
-plt.ylabel("Quote value") 
+plt.ylabel("Quote value")
 plt.legend(bbox_to_anchor=(1.05, 0.8), loc="upper left")
 _ = plt.title("Model predictions using a ShuffleSplit strategy")
 
 # %% [markdown]
-# In this time-series, we see a relationship between a sample at the time `t`
-# and a sample at `t+1`, and by the nature or structure of any time series, we can not know the value
-# at time `t+1` whithout knowing the value at time `t`. In that sense, we are violating
-# the i.i.d. assumption
-# 
-# The insight to get is the following: we obseve that the model predicts quite well in terms of the $R^2$
-# and the mean squared error, but that is only because the testing samples are next to some training samples,
-# contradicting the structure of the time series, in other words, the model is memorizing the training data 
-# and predicting the testing data filling the gaps, but not learning anything from the training data.
+# From the plot above, we can see that the training and testing samples are
+# alternating. This structure effectively evaluates the model’s ability to
+# interpolate between neighboring data points, rather than its true
+# generalization ability. As a result, the model’s predictions are close to the
+# actual values, even if it has not learned anything meaningful from the data.
+# This is a form of **data leakage**, where the model gains access to future
+# information (testing data) while training, leading to an over-optimistic
+# estimate of the generalization performance. This violates the time-series
+# dependency structure, where future data should not influence predictions made
+# at earlier time points.
 #
-# An easy way to verify this hypothesis is to not shuffle the data when doing
+# An easy way to verify this is to not shuffle the data during
 # the split. In this case, we will use the first 75% of the data to train and
-# the remaining data to test. This way of splitting the data maintains the
-# time order of the data.
+# the remaining data to test. This way we preserve the time order of the data, and
+# ensure training on past data and evaluating on future data.
 
 # %%
 data_train, data_test, target_train, target_test = train_test_split(
@@ -178,11 +175,8 @@ target_predicted = regressor.predict(data_test)
 target_predicted = pd.Series(target_predicted, index=target_test.index)
 
 # %%
-
 test_score = r2_score(target_test, target_predicted)
-mse_score = mean_squared_error(target_test, target_predicted)
 print(f"The R2 on this single split is: {test_score:.2f}")
-print(f"The mean squared error on this single split is: {mse_score:.2f}")
 
 # %% [markdown]
 # In this case, we see that our model is not magical anymore. Indeed, it
@@ -232,9 +226,7 @@ print(f"The mean R2 is: {test_score.mean():.2f} ± {test_score.std():.2f}")
 from sklearn.model_selection import TimeSeriesSplit
 
 cv = TimeSeriesSplit(n_splits=groups.nunique())
-test_score = cross_val_score(
-    regressor, data, target, cv=cv, n_jobs=2
-)
+test_score = cross_val_score(regressor, data, target, cv=cv, n_jobs=2)
 print(f"The mean R2 is: {test_score.mean():.2f} ± {test_score.std():.2f}")
 
 # %% [markdown]

--- a/python_scripts/cross_validation_time.py
+++ b/python_scripts/cross_validation_time.py
@@ -153,9 +153,7 @@ _ = plt.title("Model predictions using a ShuffleSplit strategy")
 # actual values, even if it has not learned anything meaningful from the data.
 # This is a form of **data leakage**, where the model gains access to future
 # information (testing data) while training, leading to an over-optimistic
-# estimate of the generalization performance. This violates the time-series
-# dependency structure, where future data should not influence predictions made
-# at earlier time points.
+# estimate of the generalization performance.
 #
 # An easy way to verify this is to not shuffle the data during
 # the split. In this case, we will use the first 75% of the data to train and

--- a/python_scripts/cross_validation_time.py
+++ b/python_scripts/cross_validation_time.py
@@ -76,7 +76,6 @@ data_test.sort_index(ascending=True, inplace=True)
 target_train.sort_index(ascending=True, inplace=True)
 target_test.sort_index(ascending=True, inplace=True)
 
-
 # %% [markdown]
 # We will use a decision tree regressor that we expect to overfit and thus not
 # generalize to unseen data. We use a `ShuffleSplit` cross-validation to


### PR DESCRIPTION
Fixes #786. This PR:
- Complements on the description;
- Corrects the render of the plots by ordering the index;
- Corrects a warning being raised by using `groups` with `TimeSeriesSplit`;
- Introduces a clearer explanation on why the cross-validation with shuffle is not adequate for time series.