### PR TITLE
CI Use actions upload-artifact and download-artifact v4 

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Upload jupyter-book artifact for preview in PRs
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: jupyter-book
         path: |

--- a/.github/workflows/jupyter-book-pr-preview.yml
+++ b/.github/workflows/jupyter-book-pr-preview.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           run-id: ${{ github.event.workflow_run.id }}
           name: jupyter-book
 

--- a/.github/workflows/jupyter-book-pr-preview.yml
+++ b/.github/workflows/jupyter-book-pr-preview.yml
@@ -19,11 +19,10 @@ jobs:
           sha: ${{ github.event.workflow_run.head_sha }}
           context: 'JupyterBook preview'
 
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: deploy-gh-pages.yml
-          run_id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
           name: jupyter-book
 
       - name: Get pull request number


### PR DESCRIPTION
download-artifact v4 supports downloading artifact from workflow run-id.

Closes https://github.com/INRIA/scikit-learn-mooc/pull/782 dependabot PR that was suggesting to update the `dawidd6/action-download-artifact` for security reasons.

Also artifact v3 is going to stop being supported end of January 2025 see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.

I am trying to do some basic testing in my fork in https://github.com/lesteve/scikit-learn-mooc/pull/2 prior to merging.