### PR TITLE
MNT Fix Binder link

### DIFF
--- a/jupyter-book/_static/sklearn_mooc.js
+++ b/jupyter-book/_static/sklearn_mooc.js
@@ -18,6 +18,20 @@
         };
     }
 
+    function adjustBinderLink() {
+        // Binder links to .py instead of .ipynb. In an ideal world, there
+        // would be a way to do it in _config.yml or you could tell Jupyter to
+        // use the Notebook interface to open the .py but ?factory=Notebook
+        // does not work on the mybinder.org URL only on the
+        // hub.2i2c.mybinder.org URL
+        var elements = document.querySelectorAll('.dropdown-launch-buttons a');
+        elements.forEach(
+            function(el) {
+                el.href = el.href.replace(/python_scripts\/(.+)\.py/, "notebooks/$1.ipynb");
+            }
+        );
+    }
+
     function displayContentOnly() {
         removeIfExists(document.querySelector('#site-navigation'));
         removeIfExists(document.querySelector('.topbar'));
@@ -46,5 +60,6 @@
         if (inIframe() || contentOnly()) {
             displayContentOnly();
         }
+        adjustBinderLink();
     });
 }());


### PR DESCRIPTION
It seems like the Binder link is opening a `.py` file and not a notebook. See [page](https://inria.github.io/scikit-learn-mooc/python_scripts/01_tabular_data_exploration.html) and [Binder link](
https://mybinder.org/v2/gh/INRIA/scikit-learn-mooc/main?urlpath=tree/python_scripts/01_tabular_data_exploration.py). It used to work a while ago because with the legacy notebook interface, jupytext was opening the `.py` as a notebook.


Now that Binder is supposed to be more stable, maybe it is worth fixing.

Close https://github.com/INRIA/scikit-learn-mooc/issues/190.

This seems to work, see [this page](https://pull-request-807--scikit-learn-mooc.netlify.app/python_scripts/01_tabular_data_exploration) in the rendered doc.

This seems a bit hacky but I did not find anything cleaner unfortunately ... 
