### PR TITLE
MNT Fix several FutureWarnings

### DIFF
--- a/notebooks/datasets_bike_rides.ipynb
+++ b/notebooks/datasets_bike_rides.ipynb
@@ -271,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_ride.resample(\"60S\").mean().plot()\n",
+    "data_ride.resample(\"60s\").mean().plot()\n",
     "plt.legend(bbox_to_anchor=(1.05, 1), loc=\"upper left\")\n",
     "_ = plt.title(\"Sensor values for different cyclist measurements\")"
    ]

--- a/notebooks/ensemble_adaboost.ipynb
+++ b/notebooks/ensemble_adaboost.ipynb
@@ -271,7 +271,7 @@
     "\n",
     "estimator = DecisionTreeClassifier(max_depth=3, random_state=0)\n",
     "adaboost = AdaBoostClassifier(\n",
-    "    estimator=estimator, n_estimators=3, algorithm=\"SAMME\", random_state=0\n",
+    "    estimator=estimator, n_estimators=3, random_state=0\n",
     ")\n",
     "adaboost.fit(data, target)"
    ]

--- a/notebooks/linear_models_regularization.ipynb
+++ b/notebooks/linear_models_regularization.ipynb
@@ -618,7 +618,7 @@
     "ridge = make_pipeline(\n",
     "    MinMaxScaler(),\n",
     "    PolynomialFeatures(degree=2, include_bias=False),\n",
-    "    RidgeCV(alphas=alphas, store_cv_values=True),\n",
+    "    RidgeCV(alphas=alphas, store_cv_results=True),\n",
     ")"
    ]
   },
@@ -677,7 +677,7 @@
     "It indicates that our model is not overfitting.\n",
     "\n",
     "When fitting the ridge regressor, we also requested to store the error found\n",
-    "during cross-validation (by setting the parameter `store_cv_values=True`). We\n",
+    "during cross-validation (by setting the parameter `store_cv_results=True`). We\n",
     "can plot the mean squared error for the different `alphas` regularization\n",
     "strengths that we tried. The error bars represent one standard deviation of the\n",
     "average mean square error across folds for a given value of `alpha`."
@@ -690,7 +690,7 @@
    "outputs": [],
    "source": [
     "mse_alphas = [\n",
-    "    est[-1].cv_values_.mean(axis=0) for est in cv_results[\"estimator\"]\n",
+    "    est[-1].cv_results_.mean(axis=0) for est in cv_results[\"estimator\"]\n",
     "]\n",
     "cv_alphas = pd.DataFrame(mse_alphas, columns=alphas)\n",
     "cv_alphas = cv_alphas.aggregate([\"mean\", \"std\"]).T\n",

--- a/notebooks/parameter_tuning_nested.ipynb
+++ b/notebooks/parameter_tuning_nested.ipynb
@@ -70,6 +70,7 @@
     "        (\"cat_preprocessor\", categorical_preprocessor, categorical_columns),\n",
     "    ],\n",
     "    remainder=\"passthrough\",\n",
+    "    force_int_remainder_cols=False,  # Silence a warning in scikit-learn v1.6.\n",
     ")"
    ]
   },

--- a/notebooks/parameter_tuning_randomized_search.ipynb
+++ b/notebooks/parameter_tuning_randomized_search.ipynb
@@ -121,6 +121,7 @@
     "preprocessor = ColumnTransformer(\n",
     "    [(\"cat_preprocessor\", categorical_preprocessor, categorical_columns)],\n",
     "    remainder=\"passthrough\",\n",
+    "    force_int_remainder_cols=False,  # Silence a warning in scikit-learn v1.6.\n",
     ")"
    ]
   },

--- a/python_scripts/01_tabular_data_exploration_ex_01.py
+++ b/python_scripts/01_tabular_data_exploration_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.15.2
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/02_numerical_pipeline_ex_00.py
+++ b/python_scripts/02_numerical_pipeline_ex_00.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.15.2
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/02_numerical_pipeline_ex_01.py
+++ b/python_scripts/02_numerical_pipeline_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.15.2
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/03_categorical_pipeline_ex_01.py
+++ b/python_scripts/03_categorical_pipeline_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.15.2
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/03_categorical_pipeline_ex_02.py
+++ b/python_scripts/03_categorical_pipeline_ex_02.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.15.2
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/cross_validation_ex_01.py
+++ b/python_scripts/cross_validation_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3
@@ -45,7 +45,7 @@ target = blood_transfusion["Class"]
 # exercise.
 #
 # Also, this classifier can become more flexible/expressive by using a so-called
-# kernel that makes the model become non-linear. Again, no undestanding regarding
+# kernel that makes the model become non-linear. Again, no understanding regarding
 # the mathematics is required to accomplish this exercise.
 #
 # We will use an RBF kernel where a parameter `gamma` allows to tune the

--- a/python_scripts/cross_validation_ex_02.py
+++ b/python_scripts/cross_validation_ex_02.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/datasets_bike_rides.py
+++ b/python_scripts/datasets_bike_rides.py
@@ -155,7 +155,7 @@ _ = plt.title("Sensor values for different cyclist measurements")
 # smoother visualization.
 
 # %%
-data_ride.resample("60S").mean().plot()
+data_ride.resample("60s").mean().plot()
 plt.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
 _ = plt.title("Sensor values for different cyclist measurements")
 

--- a/python_scripts/ensemble_adaboost.py
+++ b/python_scripts/ensemble_adaboost.py
@@ -190,7 +190,7 @@ from sklearn.ensemble import AdaBoostClassifier
 
 estimator = DecisionTreeClassifier(max_depth=3, random_state=0)
 adaboost = AdaBoostClassifier(
-    estimator=estimator, n_estimators=3, algorithm="SAMME", random_state=0
+    estimator=estimator, n_estimators=3, random_state=0
 )
 adaboost.fit(data, target)
 

--- a/python_scripts/ensemble_ex_01.py
+++ b/python_scripts/ensemble_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/ensemble_ex_02.py
+++ b/python_scripts/ensemble_ex_02.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/ensemble_ex_03.py
+++ b/python_scripts/ensemble_ex_03.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/ensemble_ex_04.py
+++ b/python_scripts/ensemble_ex_04.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/feature_selection_ex_01.py
+++ b/python_scripts/feature_selection_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_01.py
+++ b/python_scripts/linear_models_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_02.py
+++ b/python_scripts/linear_models_ex_02.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_03.py
+++ b/python_scripts/linear_models_ex_03.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_ex_04.py
+++ b/python_scripts/linear_models_ex_04.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.15.2
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/linear_models_regularization.py
+++ b/python_scripts/linear_models_regularization.py
@@ -421,7 +421,7 @@ alphas = np.logspace(-7, 5, num=100)
 ridge = make_pipeline(
     MinMaxScaler(),
     PolynomialFeatures(degree=2, include_bias=False),
-    RidgeCV(alphas=alphas, store_cv_values=True),
+    RidgeCV(alphas=alphas, store_cv_results=True),
 )
 
 # %%
@@ -458,14 +458,14 @@ print(
 # It indicates that our model is not overfitting.
 #
 # When fitting the ridge regressor, we also requested to store the error found
-# during cross-validation (by setting the parameter `store_cv_values=True`). We
+# during cross-validation (by setting the parameter `store_cv_results=True`). We
 # can plot the mean squared error for the different `alphas` regularization
 # strengths that we tried. The error bars represent one standard deviation of the
 # average mean square error across folds for a given value of `alpha`.
 
 # %%
 mse_alphas = [
-    est[-1].cv_values_.mean(axis=0) for est in cv_results["estimator"]
+    est[-1].cv_results_.mean(axis=0) for est in cv_results["estimator"]
 ]
 cv_alphas = pd.DataFrame(mse_alphas, columns=alphas)
 cv_alphas = cv_alphas.aggregate(["mean", "std"]).T

--- a/python_scripts/metrics_ex_01.py
+++ b/python_scripts/metrics_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/metrics_ex_02.py
+++ b/python_scripts/metrics_ex_02.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3
@@ -52,8 +52,8 @@ target /= 1000
 # Write your code here.
 
 # %% [markdown]
-# Then, instead of using the $R^2$ score, use the mean absolute error. You need
-# to refer to the documentation for the `scoring` parameter.
+# Then, instead of using the $R^2$ score, use the mean absolute error (MAE). You
+# may need to refer to the documentation for the `scoring` parameter.
 
 # %%
 # Write your code here.
@@ -62,6 +62,9 @@ target /= 1000
 # Finally, use the `cross_validate` function and compute multiple scores/errors
 # at once by passing a list of scorers to the `scoring` parameter. You can
 # compute the $R^2$ score and the mean absolute error for instance.
+
+# %%
+# Write your code here.
 
 # %%
 # Write your code here.

--- a/python_scripts/parameter_tuning_ex_02.py
+++ b/python_scripts/parameter_tuning_ex_02.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3
@@ -68,7 +68,7 @@ model = Pipeline(
 # %% [markdown]
 # Use the previously defined model (called `model`) and using two nested `for`
 # loops, make a search of the best combinations of the `learning_rate` and
-# `max_leaf_nodes` parameters. In this regard, you have to train and test the
+# `max_leaf_nodes` parameters. In this regard, you need to train and test the
 # model by setting the parameters. The evaluation of the model should be
 # performed using `cross_val_score` on the training set. Use the following
 # parameters search:

--- a/python_scripts/parameter_tuning_ex_03.py
+++ b/python_scripts/parameter_tuning_ex_03.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3
@@ -29,8 +29,8 @@ data_train, data_test, target_train, target_test = train_test_split(
 )
 
 # %% [markdown]
-# In this exercise, we progressively define the regression pipeline and
-# later tune its hyperparameters.
+# In this exercise, we progressively define the regression pipeline and later
+# tune its hyperparameters.
 #
 # Start by defining a pipeline that:
 # * uses a `StandardScaler` to normalize the numerical data;

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -89,6 +89,8 @@ from sklearn.compose import ColumnTransformer
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
+    force_int_remainder_cols=False,  #  avoid warning in scikit-learn v1.6
+    # we make explicit that remainder columns are not forced to be integers
 )
 
 # %% [markdown]

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -89,8 +89,9 @@ from sklearn.compose import ColumnTransformer
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    force_int_remainder_cols=False,  # avoid warning in scikit-learn v1.6
-    # we make explicit that remainder columns are not forced to be integers
+    # Silence a deprecation warning in scikit-learn v1.6 related to how
+    # the `transformers_` attribute stores column identifiers internally.
+    force_int_remainder_cols=False,
 )
 
 # %% [markdown]

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -89,8 +89,8 @@ from sklearn.compose import ColumnTransformer
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    # Silence a deprecation warning in scikit-learn v1.6 related to how
-    # the `transformers_` attribute stores column identifiers internally.
+    # Silence a deprecation warning in scikit-learn v1.6 related to how the
+    # ColumnTransformer stores an attribute that we do not use in this notebook
     force_int_remainder_cols=False,
 )
 

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -89,7 +89,7 @@ from sklearn.compose import ColumnTransformer
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    force_int_remainder_cols=False,  #  avoid warning in scikit-learn v1.6
+    force_int_remainder_cols=False,  # avoid warning in scikit-learn v1.6
     # we make explicit that remainder columns are not forced to be integers
 )
 

--- a/python_scripts/parameter_tuning_nested.py
+++ b/python_scripts/parameter_tuning_nested.py
@@ -56,6 +56,7 @@ preprocessor = ColumnTransformer(
         ("cat_preprocessor", categorical_preprocessor, categorical_columns),
     ],
     remainder="passthrough",
+    force_int_remainder_cols=False, #  avoid warning in scikit-learn v1.6
 )
 
 # %%

--- a/python_scripts/parameter_tuning_nested.py
+++ b/python_scripts/parameter_tuning_nested.py
@@ -56,7 +56,7 @@ preprocessor = ColumnTransformer(
         ("cat_preprocessor", categorical_preprocessor, categorical_columns),
     ],
     remainder="passthrough",
-    force_int_remainder_cols=False,  #  avoid warning in scikit-learn v1.6
+    force_int_remainder_cols=False,  # avoid warning in scikit-learn v1.6
 )
 
 # %%

--- a/python_scripts/parameter_tuning_nested.py
+++ b/python_scripts/parameter_tuning_nested.py
@@ -56,7 +56,7 @@ preprocessor = ColumnTransformer(
         ("cat_preprocessor", categorical_preprocessor, categorical_columns),
     ],
     remainder="passthrough",
-    force_int_remainder_cols=False, #  avoid warning in scikit-learn v1.6
+    force_int_remainder_cols=False,  #  avoid warning in scikit-learn v1.6
 )
 
 # %%

--- a/python_scripts/parameter_tuning_nested.py
+++ b/python_scripts/parameter_tuning_nested.py
@@ -56,7 +56,7 @@ preprocessor = ColumnTransformer(
         ("cat_preprocessor", categorical_preprocessor, categorical_columns),
     ],
     remainder="passthrough",
-    force_int_remainder_cols=False,  # avoid warning in scikit-learn v1.6
+    force_int_remainder_cols=False,  # Silence a warning in scikit-learn v1.6.
 )
 
 # %%

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -73,7 +73,7 @@ categorical_preprocessor = OrdinalEncoder(
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    force_int_remainder_cols=False,  #  avoid warning in scikit-learn v1.6
+    force_int_remainder_cols=False,  # avoid warning in scikit-learn v1.6
 )
 
 # %%

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -73,7 +73,7 @@ categorical_preprocessor = OrdinalEncoder(
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    force_int_remainder_cols=False,  # avoid warning in scikit-learn v1.6
+    force_int_remainder_cols=False,  # Silence a warning in scikit-learn v1.6.
 )
 
 # %%

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -73,6 +73,7 @@ categorical_preprocessor = OrdinalEncoder(
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
+    force_int_remainder_cols=False, #  avoid warning in scikit-learn v1.6
 )
 
 # %%

--- a/python_scripts/parameter_tuning_randomized_search.py
+++ b/python_scripts/parameter_tuning_randomized_search.py
@@ -73,7 +73,7 @@ categorical_preprocessor = OrdinalEncoder(
 preprocessor = ColumnTransformer(
     [("cat_preprocessor", categorical_preprocessor, categorical_columns)],
     remainder="passthrough",
-    force_int_remainder_cols=False, #  avoid warning in scikit-learn v1.6
+    force_int_remainder_cols=False,  #  avoid warning in scikit-learn v1.6
 )
 
 # %%

--- a/python_scripts/trees_ex_01.py
+++ b/python_scripts/trees_ex_01.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/python_scripts/trees_ex_02.py
+++ b/python_scripts/trees_ex_02.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.16.7
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3


### PR DESCRIPTION
Follows from https://github.com/INRIA/scikit-learn-mooc/pull/790.

Bumping the version scikit-learn to v1.6 introduced some FutureWarnings. This PR fixes them, as well as a `FutureWarning` related to resampling time indexed data.

Note: As mentioned in https://github.com/INRIA/scikit-learn-mooc/issues/789#issuecomment-2575302965, auto-updates are disabled on FUN, where still run on scikit-learn v1.3. Therefore building the notebooks after this PR should be done in combination with an update of the Jupyter image in FUN.