### PR TITLE
Remove custom sphinx-book-theme version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,9 +4,6 @@ matplotlib
 seaborn >= 0.13
 plotly
 jupyter-book>=0.11
-# Partial fix for the navbar scrollToActive behavior:
-# https://github.com/executablebooks/sphinx-book-theme/issues/541
-sphinx-book-theme @ git+https://github.com/executablebooks/sphinx-book-theme.git@aca0f7fd39314ec3283f1ff798b4bf8ee9b49cad
 jupytext
 beautifulsoup4
 IPython


### PR DESCRIPTION
This should no longer be needed since https://github.com/executablebooks/sphinx-book-theme/pull/754 was merged and released.