### PR TITLE
FIX Penguin figures not rendering

### DIFF
--- a/notebooks/trees_dataset.ipynb
+++ b/notebooks/trees_dataset.ipynb
@@ -21,7 +21,7 @@
     "species:\n",
     "\n",
     "![Image of\n",
-    "penguins](https://github.com/allisonhorst/palmerpenguins/raw/master/man/figures/lter_penguins.png)\n",
+    "penguins](https://github.com/allisonhorst/palmerpenguins/raw/main/man/figures/lter_penguins.png)\n",
     "\n",
     "This problem is a classification problem since the target is categorical. We\n",
     "limit our input data to a subset of the original features to simplify our\n",
@@ -30,7 +30,7 @@
     "penguins' culmen with the illustration below:\n",
     "\n",
     "![Image of\n",
-    "culmen](https://github.com/allisonhorst/palmerpenguins/raw/master/man/figures/culmen_depth.png)\n",
+    "culmen](https://github.com/allisonhorst/palmerpenguins/raw/main/man/figures/culmen_depth.png)\n",
     "\n",
     "We start by loading this subset of the dataset."
    ]

--- a/python_scripts/trees_dataset.py
+++ b/python_scripts/trees_dataset.py
@@ -23,7 +23,7 @@
 # species:
 #
 # ![Image of
-# penguins](https://github.com/allisonhorst/palmerpenguins/raw/master/man/figures/lter_penguins.png)
+# penguins](https://github.com/allisonhorst/palmerpenguins/raw/main/man/figures/lter_penguins.png)
 #
 # This problem is a classification problem since the target is categorical. We
 # limit our input data to a subset of the original features to simplify our
@@ -32,7 +32,7 @@
 # penguins' culmen with the illustration below:
 #
 # ![Image of
-# culmen](https://github.com/allisonhorst/palmerpenguins/raw/master/man/figures/culmen_depth.png)
+# culmen](https://github.com/allisonhorst/palmerpenguins/raw/main/man/figures/culmen_depth.png)
 #
 # We start by loading this subset of the dataset.
 


### PR DESCRIPTION
The figures in [The penguins datasets notebook](https://inria.github.io/scikit-learn-mooc/python_scripts/trees_dataset.html) are not rendering correctly as `master` was renaimed to `main` in the [original repo](https://allisonhorst.github.io/palmerpenguins/).

This PR fixes the issue.