### PR TITLE
minor docstring fixups

### DIFF
--- a/python_scripts/ensemble_bagging.py
+++ b/python_scripts/ensemble_bagging.py
@@ -78,7 +78,7 @@ plt.legend()
 _ = plt.title("Predictions by a single decision tree")
 
 # %% [markdown]
-# Let's see how we can use bootstraping to learn several trees.
+# Let's see how we can use bootstrapping to learn several trees.
 #
 # ## Bootstrap resampling
 #

--- a/python_scripts/linear_models_feature_engineering_classification.py
+++ b/python_scripts/linear_models_feature_engineering_classification.py
@@ -439,7 +439,7 @@ plot_decision_boundary(classifier, title="Spline + RBF Nystroem classifier")
 # - Transformers such as `KBinsDiscretizer` and `SplineTransformer` can be used
 #   to engineer non-linear features independently for each original feature.
 # - As a result, these transformers cannot capture interactions between the
-#   orignal features (and then would fail on the XOR classification task).
+#   original features (and then would fail on the XOR classification task).
 # - Despite this limitation they already augment the expressivity of the
 #   pipeline, which can be sufficient for some datasets.
 # - They also favor axis-aligned decision boundaries, in particular in the low


### PR DESCRIPTION
Hey team! Fixed errors:

python_scripts/linear_models_feature_engineering_classification.py
`bootstraping` - `bootstrapping`

python_scripts/linear_models_feature_engineering_classification.py
`orignal` - `original`