### PR TITLE
Add cross-validation diagram to GridSearchCV notebook

### DIFF
--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -124,9 +124,13 @@ model
 # Let's see how to use the `GridSearchCV` estimator for doing such search. Since
 # the grid-search is costly, we only explore the combination learning-rate and
 # the maximum number of nodes.
+### Cross-Validation Visualization
+![Grid Search CV](../figures/cross_validation_train_test_diagram.png)
 
-# %%
+#This diagram illustrates how GridSearchCV uses cross-validation to split the dataset during hyperparameter tuning.
+
 # %%time
+
 from sklearn.model_selection import GridSearchCV
 
 param_grid = {


### PR DESCRIPTION
###What does this PR do?
 This PR adds the cross-validation visualization diagram to the parameter_tuning_grid_search.py notebook, just before the introduction of GridSearchCV.

Uses Markdown for clean integration

Helps learners understand how data is split during hyperparameter tuning

Fixes #752
![Screenshot (231)](https://github.com/user-attachments/assets/17303216-c1c7-4514-88b8-9f9964492a5a)
