### PR TITLE
Update 02_numerical_pipeline_scaling.py

### DIFF
--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -103,7 +103,7 @@ scaler.fit(data_train)
 
 # %% [markdown]
 # The `fit` method for transformers is similar to the `fit` method for
-# predictors. The main difference is that the former has a single argument (the
+# estimators. The main difference is that the former has a single argument (the
 # data matrix), whereas the latter has two arguments (the data matrix and the
 # target).
 #


### PR DESCRIPTION
in the chapter of First model with scikit learn, it says an object that has a fit method is called an estimator.  Correct if I am wrong but here it says the fit method is similar to what we saw with the predictors where in fact it should be estimators. Thank you