### PR TITLE
Add README and License for Bike Rides Dataset Add bike rides license

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,2 +1,3 @@
 `cps_85_wages.csv` is available at https://www.openml.org/d/534
 `adult-census.csv` is available at https://www.openml.org/d/15950
+`bike_rides.csv` is available at https://github.com/INRIA/scikit-learn-mooc/blob/main/datasets/bike_rides.csv

--- a/datasets/bike_rides_LICENSE.txt
+++ b/datasets/bike_rides_LICENSE.txt
@@ -15,6 +15,6 @@ Under the following terms:
 
 No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
 
-Suggested citation: Guillaume Lemaitre. (2025). [Dataset Name]. Licensed under CC BY 4.0. Available at: https://github.com/INRIA/scikit-learn-mooc/blob/main/datasets/bike_rides.csv
+Suggested citation: Guillaume Lemaitre. (2025). Bike Rides Dataset. Licensed under CC BY 4.0. Available at: https://github.com/INRIA/scikit-learn-mooc/blob/main/datasets/bike_rides.csv
 
 Full license text: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/datasets/bike_rides_LICENSE.txt
+++ b/datasets/bike_rides_LICENSE.txt
@@ -1,0 +1,20 @@
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+Dataset: bike_rides.csv
+Author: Guillaume Lemaitre
+Year: 2025
+
+This work is licensed under the Creative Commons Attribution 4.0 International License.
+
+You are free to:
+- Share — copy and redistribute the material in any medium or format
+- Adapt — remix, transform, and build upon the material for any purpose, even commercially
+
+Under the following terms:
+- Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+Suggested citation: Guillaume Lemaitre. (2025). [Dataset Name]. Licensed under CC BY 4.0. Available at: https://github.com/INRIA/scikit-learn-mooc/blob/main/datasets/bike_rides.csv
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/python_scripts/parameter_tuning_grid_search.py
+++ b/python_scripts/parameter_tuning_grid_search.py
@@ -124,9 +124,13 @@ model
 # Let's see how to use the `GridSearchCV` estimator for doing such search. Since
 # the grid-search is costly, we only explore the combination learning-rate and
 # the maximum number of nodes.
+### Cross-Validation Visualization
+![Grid Search CV](../figures/cross_validation_train_test_diagram.png)
 
-# %%
+#This diagram illustrates how GridSearchCV uses cross-validation to split the dataset during hyperparameter tuning.
+
 # %%time
+
 from sklearn.model_selection import GridSearchCV
 
 param_grid = {


### PR DESCRIPTION
##What does this PR do?
This PR adds documentation and licensing information for the bike rides dataset.
Fixes #837 
##Changes Made
Added datasets/README.md with dataset description and usage details.

Added datasets/bike_rides_LICENSE.txt containing licensing terms.

Purpose
Including this documentation ensures that dataset usage guidelines and license information are clear to all contributors and users.