### PR TITLE
MTN Made the distinction between predictor and transformer clearer

### DIFF
--- a/python_scripts/02_numerical_pipeline_introduction.py
+++ b/python_scripts/02_numerical_pipeline_introduction.py
@@ -101,11 +101,18 @@ _ = model.fit(data, target)
 # ![Predictor fit diagram](../figures/api_diagram-predictor.fit.svg)
 #
 # In scikit-learn an object that has a `fit` method is called an **estimator**.
+# If the estimator additionally has :
+# - a  `predict` method, it is called a **predictor**. Examples of predictors
+#   are classifiers or regressors.
+# - a `transform` method, it is called a **transformer**. Examples of
+#   transformers are scalers or encoders. We will see more about transformers in
+#   the next notebook.
+#
 # The method `fit` is composed of two elements: (i) a **learning algorithm** and
 # (ii) some **model states**. The learning algorithm takes the training data and
 # training target as input and sets the model states. These model states are
-# later used to either predict (for classifiers and regressors) or transform
-# data (for transformers).
+# later used to either predict or transform data as explained above. See the
+# glossary for more detailed definitions.
 #
 # Both the learning algorithm and the type of model states are specific to each
 # type of model.
@@ -124,8 +131,7 @@ _ = model.fit(data, target)
 target_predicted = model.predict(data)
 
 # %% [markdown]
-# An estimator (an object with a `fit` method) with a `predict` method is called
-# a **predictor**. We can illustrate the prediction mechanism as follows:
+# We can illustrate the prediction mechanism as follows:
 #
 # ![Predictor predict diagram](../figures/api_diagram-predictor.predict.svg)
 #

--- a/python_scripts/02_numerical_pipeline_scaling.py
+++ b/python_scripts/02_numerical_pipeline_scaling.py
@@ -88,6 +88,7 @@ data_train.describe()
 # We show how to apply such normalization using a scikit-learn transformer
 # called `StandardScaler`. This transformer shifts and scales each feature
 # individually so that they all have a 0-mean and a unit standard deviation.
+# We recall that transformers are estimators that have a `transform` method.
 #
 # We now investigate different steps used in scikit-learn to achieve such a
 # transformation of the data.


### PR DESCRIPTION
As per #851 , this PR clarifies the distinction between predictors and transformers when they are introduced in the course.
