### PR TITLE
FIX HistGradientBoosting fitting time too long

### DIFF
--- a/python_scripts/ensemble_hist_gradient_boosting.py
+++ b/python_scripts/ensemble_hist_gradient_boosting.py
@@ -58,7 +58,7 @@ cv_results_gbdt = cross_validate(
     data,
     target,
     scoring="neg_mean_absolute_error",
-    n_jobs=2,
+    # n_jobs=2, # Uncomment this line if you run locally
 )
 
 # %%
@@ -122,7 +122,7 @@ cv_results_gbdt = cross_validate(
     data,
     target,
     scoring="neg_mean_absolute_error",
-    n_jobs=2,
+    # n_jobs=2, # Uncomment this line if you run locally
 )
 
 # %%
@@ -161,7 +161,7 @@ cv_results_hgbdt = cross_validate(
     data,
     target,
     scoring="neg_mean_absolute_error",
-    n_jobs=2,
+    # n_jobs=2, # Uncomment this line if you run locally
 )
 
 # %%


### PR DESCRIPTION
As per [this question](https://mooc-forums.inria.fr/moocsl/t/fitting-time-of-histgradientboostingregressor/15930) related to [this issue](https://github.com/scikit-learn/scikit-learn/issues/30662), commented the n_jobs parameters so that the results make sense.