### PR TITLE
MTN Exercise M4.01 target correction

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,4 +13,4 @@ dependencies:
   - packaging
   - pip
   - pip:
-    - jupyter-book >= 0.11
+    - jupyter-book < 2.0

--- a/notebooks/linear_models_ex_01.ipynb
+++ b/notebooks/linear_models_ex_01.ipynb
@@ -43,7 +43,7 @@
     "penguins = pd.read_csv(\"../datasets/penguins_regression.csv\")\n",
     "feature_name = \"Flipper Length (mm)\"\n",
     "target_name = \"Body Mass (g)\"\n",
-    "data, target = penguins[[feature_name]], penguins[target_name]"
+    "data, target = penguins[[feature_name]], penguins[[target_name]]"
    ]
   },
   {

--- a/notebooks/linear_models_sol_01.ipynb
+++ b/notebooks/linear_models_sol_01.ipynb
@@ -43,7 +43,7 @@
     "penguins = pd.read_csv(\"../datasets/penguins_regression.csv\")\n",
     "feature_name = \"Flipper Length (mm)\"\n",
     "target_name = \"Body Mass (g)\"\n",
-    "data, target = penguins[[feature_name]], penguins[target_name]"
+    "data, target = penguins[[feature_name]], penguins[[target_name]]"
    ]
   },
   {
@@ -152,7 +152,7 @@
     "def goodness_fit_measure(true_values, predictions):\n",
     "    # we compute the error between the true values and the predictions of our\n",
     "    # model\n",
-    "    errors = np.ravel(true_values) - np.ravel(predictions)\n",
+    "    errors = true_values - predictions\n",
     "    # We have several possible strategies to reduce all errors to a single value.\n",
     "    # Computing the mean error (sum divided by the number of element) might seem\n",
     "    # like a good solution. However, we have negative errors that will misleadingly\n",

--- a/python_scripts/linear_models_ex_01.py
+++ b/python_scripts/linear_models_ex_01.py
@@ -40,7 +40,7 @@ import pandas as pd
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
 feature_name = "Flipper Length (mm)"
 target_name = "Body Mass (g)"
-data, target = penguins[[feature_name]], penguins[target_name]
+data, target = penguins[[feature_name]], penguins[[target_name]]
 
 # %% [markdown]
 # ### Model definition

--- a/python_scripts/linear_models_sol_01.py
+++ b/python_scripts/linear_models_sol_01.py
@@ -34,7 +34,7 @@ import pandas as pd
 penguins = pd.read_csv("../datasets/penguins_regression.csv")
 feature_name = "Flipper Length (mm)"
 target_name = "Body Mass (g)"
-data, target = penguins[[feature_name]], penguins[target_name]
+data, target = penguins[[feature_name]], penguins[[target_name]]
 
 # %% [markdown]
 # ### Model definition
@@ -106,7 +106,7 @@ _ = ax.legend(loc="center left", bbox_to_anchor=(-0.25, 1.25), ncol=1)
 def goodness_fit_measure(true_values, predictions):
     # we compute the error between the true values and the predictions of our
     # model
-    errors = np.ravel(true_values) - np.ravel(predictions)
+    errors = true_values - predictions
     # We have several possible strategies to reduce all errors to a single value.
     # Computing the mean error (sum divided by the number of element) might seem
     # like a good solution. However, we have negative errors that will misleadingly

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pandas >= 1
 matplotlib
 seaborn >= 0.13
 plotly
-jupyter-book>=0.11
+jupyter-book < 2.0
 jupytext
 beautifulsoup4
 IPython


### PR DESCRIPTION
As per [this question](https://mooc-forums.inria.fr/moocsl/t/dataframes-vs-series-or-why-youre-getting-nans/15955), fixes the target definition to `penguins[[target_name]]` to prevent code complications in the solution. The solution is therefore simpler.