### PR TITLE
FIX Pin jupyter-book version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ run-code-in-wrap-up-quizzes:
 	jupytext --execute --to notebook $(WRAP_UP_DIR)/*.py
 
 $(JUPYTER_BOOK_DIR):
-	jupyter-book build $(JUPYTER_BOOK_DIR)
+	jupyter-book build ./$(JUPYTER_BOOK_DIR)
 	rm -rf $(JUPYTER_BOOK_DIR)/_build/html/{slides,figures} && cp -r slides figures $(JUPYTER_BOOK_DIR)/_build/html
 
 $(JUPYTER_BOOK_DIR)-clean:
 	# keep jupyter-cache cache folder
-	jupyter-book clean $(JUPYTER_BOOK_DIR)
+	cd $(JUPYTER_BOOK_DIR) && jupyter-book clean .
 
 $(JUPYTER_BOOK_DIR)-full-clean:
 	# deletes jupyter-cache cache folder

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ run-code-in-wrap-up-quizzes:
 	jupytext --execute --to notebook $(WRAP_UP_DIR)/*.py
 
 $(JUPYTER_BOOK_DIR):
-	jupyter-book build ./$(JUPYTER_BOOK_DIR)
+	jupyter-book build $(JUPYTER_BOOK_DIR)
 	rm -rf $(JUPYTER_BOOK_DIR)/_build/html/{slides,figures} && cp -r slides figures $(JUPYTER_BOOK_DIR)/_build/html
 
 $(JUPYTER_BOOK_DIR)-clean:
 	# keep jupyter-cache cache folder
-	cd $(JUPYTER_BOOK_DIR) && jupyter-book clean .
+	jupyter-book clean $(JUPYTER_BOOK_DIR)
 
 $(JUPYTER_BOOK_DIR)-full-clean:
 	# deletes jupyter-cache cache folder

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,4 +13,4 @@ dependencies:
   - packaging
   - pip
   - pip:
-    - jupyter-book >= 2.0
+    - jupyter-book < 2.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,4 +13,4 @@ dependencies:
   - packaging
   - pip
   - pip:
-    - jupyter-book >= 0.11
+    - jupyter-book >= 2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pandas >= 1
 matplotlib
 seaborn >= 0.13
 plotly
-jupyter-book>=0.11
+jupyter-book < 2.0
 jupytext
 beautifulsoup4
 IPython


### PR DESCRIPTION
As mentioned in #874, Jupyter Book 2 is raising an `EISDIR` error during the build in our CI. A quick attempt made me realize that bumping to Jupyter Book 2 may require a lot more effort.
This PR proposes then a quick fix, which consists on pinning a lower version.